### PR TITLE
네이버 로그인 구현 완료

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -2602,6 +2602,11 @@
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
+    "base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -6922,6 +6927,11 @@
       "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
       "dev": true
     },
+    "oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha1-vR/vr2hslrdUda7VGWQS/2DPucE="
+    },
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
@@ -7212,6 +7222,60 @@
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "dev": true
     },
+    "passport": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.4.1.tgz",
+      "integrity": "sha512-IxXgZZs8d7uFSt3eqNjM9NQ3g3uQCW5avD8mRNoXV99Yig50vjuaez6dQK2qC0kVWPRTujxY0dWgGfT09adjYg==",
+      "requires": {
+        "passport-strategy": "1.x.x",
+        "pause": "0.0.1"
+      }
+    },
+    "passport-naver": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/passport-naver/-/passport-naver-1.0.6.tgz",
+      "integrity": "sha512-5XEbJesiPVshwE0cTDvbbJrOiYSJ9VFRJTctqiZL1Xip6qOi9n7d49UesOqavLT+Ry8C7aw3zdzbmWosqHcQ/Q==",
+      "requires": {
+        "passport-oauth": "^1.0.0",
+        "underscore": "^1.8.3"
+      }
+    },
+    "passport-oauth": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth/-/passport-oauth-1.0.0.tgz",
+      "integrity": "sha1-kK/2M4dUDwIImvKM2tOep/gNd98=",
+      "requires": {
+        "passport-oauth1": "1.x.x",
+        "passport-oauth2": "1.x.x"
+      }
+    },
+    "passport-oauth1": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth1/-/passport-oauth1-1.1.0.tgz",
+      "integrity": "sha1-p96YiiEfnPRoc3cTDqdN8ycwyRg=",
+      "requires": {
+        "oauth": "0.9.x",
+        "passport-strategy": "1.x.x",
+        "utils-merge": "1.x.x"
+      }
+    },
+    "passport-oauth2": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.5.0.tgz",
+      "integrity": "sha512-kqBt6vR/5VlCK8iCx1/KpY42kQ+NEHZwsSyt4Y6STiNjU+wWICG1i8ucc1FapXDGO15C5O5VZz7+7vRzrDPXXQ==",
+      "requires": {
+        "base64url": "3.x.x",
+        "oauth": "0.9.x",
+        "passport-strategy": "1.x.x",
+        "uid2": "0.0.x",
+        "utils-merge": "1.x.x"
+      }
+    },
+    "passport-strategy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+      "integrity": "sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ="
+    },
     "path-dirname": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
@@ -7254,6 +7318,11 @@
       "requires": {
         "pify": "^2.0.0"
       }
+    },
+    "pause": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+      "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10="
     },
     "performance-now": {
       "version": "2.1.0",
@@ -9099,6 +9168,11 @@
         "cls-hooked": "^4.2.2"
       }
     },
+    "uid2": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
+      "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I="
+    },
     "undefsafe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.3.tgz",
@@ -9107,6 +9181,11 @@
       "requires": {
         "debug": "^2.2.0"
       }
+    },
+    "underscore": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.11.0.tgz",
+      "integrity": "sha512-xY96SsN3NA461qIRKZ/+qox37YXPtSBswMGfiNptr+wrt6ds4HaMw23TP612fEyGekRE6LNRiLYr/aqbHXNedw=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",

--- a/server/package.json
+++ b/server/package.json
@@ -9,7 +9,8 @@
     "start": "babel-node src/main",
     "start:dev": "nodemon -e js --watch src --exec babel-node src/main",
     "start:prod": "node dist/main",
-    "test": "jest"
+    "test": "jest",
+    "lint": "eslint ."
   },
   "keywords": [],
   "author": "",
@@ -24,6 +25,8 @@
     "helmet": "^4.2.0",
     "jsonwebtoken": "^8.5.1",
     "mysql2": "^2.2.5",
+    "passport": "^0.4.1",
+    "passport-naver": "^1.0.6",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
     "typeorm": "^0.2.29",

--- a/server/src/Application.js
+++ b/server/src/Application.js
@@ -10,9 +10,13 @@ import {
     initializeTransactionalContext,
     patchTypeORMRepositoryWithBaseRepository,
 } from 'typeorm-transactional-cls-hooked';
+import passport from 'passport';
 import { ConnectionOptionGenerator } from './common/config/database/ConnectionOptionGenerator';
 import { DatabaseEnv } from './common/env/DatabaseEnv';
 import { EnvType } from './common/env/EnvType';
+import { IndexRouter } from './router';
+import { errorHandler } from './common/middleware/errorHandler';
+import { NaverStrategy } from './common/config/passport/NaverStrategy';
 
 export class Application {
     constructor() {
@@ -30,6 +34,7 @@ export class Application {
     async initialize() {
         try {
             await this.initEnvironment();
+            this.initPassport();
             this.registerMiddleware();
             await this.initDatabase();
         } catch (error) {
@@ -64,5 +69,11 @@ export class Application {
         this.httpServer.use(cors());
         this.httpServer.use(express.json());
         this.httpServer.use(express.urlencoded({ extended: false }));
+        this.httpServer.use(IndexRouter());
+        this.httpServer.use(errorHandler);
+    }
+
+    initPassport() {
+        passport.use(new NaverStrategy());
     }
 }

--- a/server/src/ApplicationFactory.js
+++ b/server/src/ApplicationFactory.js
@@ -1,9 +1,0 @@
-import { Application } from './Application';
-
-export class ApplicationFactory {
-    static async create() {
-        const application = new Application();
-        await application.initialize();
-        return application;
-    }
-}

--- a/server/src/common/config/passport/NaverStrategy.js
+++ b/server/src/common/config/passport/NaverStrategy.js
@@ -1,0 +1,37 @@
+import { Strategy } from 'passport-naver';
+import { getRepository } from 'typeorm';
+import { User } from '../../../model/User';
+
+export class NaverStrategy extends Strategy {
+    constructor() {
+        super(
+            {
+                clientID: process.env.OAUTH_NAVER_CLIENT_ID,
+                clientSecret: process.env.OAUTH_NAVER_CLIENT_SECRET,
+                callbackURL: process.env.OAUTH_NAVER_CALLBACK_URL,
+            },
+            async (accessToken, refreshToken, profile, done) => {
+                try {
+                    const userRepository = getRepository(User);
+                    const existedUser = await userRepository.findOne({ socialId: profile?.id });
+
+                    if (existedUser === undefined) {
+                        const user = userRepository.create({
+                            socialId: profile?.id,
+                            name: profile?.displayName,
+                            // eslint-disable-next-line no-underscore-dangle
+                            profileImageUrl: profile?._json?.profile_image,
+                        });
+                        await userRepository.save(user);
+
+                        return done(null, user);
+                    }
+
+                    return done(null, existedUser);
+                } catch (error) {
+                    return done(error, null);
+                }
+            },
+        );
+    }
+}

--- a/server/src/common/util/JwtAsyncWrapper.js
+++ b/server/src/common/util/JwtAsyncWrapper.js
@@ -1,0 +1,25 @@
+import { sign, verify } from 'jsonwebtoken';
+
+export class JwtAsyncWrapper {
+    static signAsync(payload, secretOrPrivateKey, options) {
+        return new Promise((resolve, reject) => {
+            sign(payload, secretOrPrivateKey, options, (err, encoded) => {
+                if (err) {
+                    reject(err);
+                }
+                resolve(encoded);
+            });
+        });
+    }
+
+    static verifyAsync(token, secretOrPublicKey, options) {
+        return new Promise((resolve, reject) => {
+            verify(token, secretOrPublicKey, options, (err, decoded) => {
+                if (err) {
+                    reject(err);
+                }
+                resolve(decoded);
+            });
+        });
+    }
+}

--- a/server/src/common/util/JwtUtil.js
+++ b/server/src/common/util/JwtUtil.js
@@ -1,0 +1,39 @@
+import { JwtAsyncWrapper } from './JwtAsyncWrapper';
+
+export class JwtUtil {
+    static instance = null;
+
+    static getInstance() {
+        if (this.instance === null) {
+            this.instance = new JwtUtil(process.env.JWT_SECRET);
+        }
+
+        return this.instance;
+    }
+
+    constructor(secret) {
+        this.secret = secret;
+    }
+
+    async generateAccessToken(payload) {
+        const accessToken = await JwtAsyncWrapper.signAsync(payload, this.secret, {
+            expiresIn: '1d',
+        });
+
+        return `Bearer ${accessToken}`;
+    }
+
+    async validateAccessToken(token) {
+        if (!this.matchBearer(token)) {
+            throw new Error();
+        }
+
+        const payload = await JwtAsyncWrapper.verifyAsync(token.split(' ')[1], this.secret);
+
+        return payload;
+    }
+
+    matchBearer(token) {
+        return token.split(' ')[0] === 'Bearer';
+    }
+}

--- a/server/src/main.js
+++ b/server/src/main.js
@@ -1,10 +1,10 @@
 import { Application } from './Application';
-import { ApplicationFactory } from './ApplicationFactory';
 
 async function main() {
-    const app = await ApplicationFactory.create();
-    await app.listen(process.env.PORT || 3000);
-    console.log(`Server listening on ${process.env.PORT || 3000}`);
+    const app = new Application();
+    await app.initialize();
+    await app.listen(process.env.PORT || 5000);
+    console.log(`Server listening on ${process.env.PORT || 5000}`);
 }
 
 main();

--- a/server/src/router/OAuthRouter.js
+++ b/server/src/router/OAuthRouter.js
@@ -1,0 +1,32 @@
+import { Router } from 'express';
+import passport from 'passport';
+import { JwtUtil } from '../common/util/JwtUtil';
+
+export const OAuthRouter = () => {
+    const router = Router();
+
+    router.get('/login/naver', passport.authenticate('naver', null));
+
+    router.get(
+        '/callback/naver',
+        passport.authenticate('naver', {
+            session: false,
+            failureRedirect: process.env.OAUTH_FAILURE_REDIRECT_URL,
+        }),
+        async (req, res) => {
+            const jwtUtil = JwtUtil.getInstance();
+            const token = await jwtUtil.generateAccessToken({
+                userId: req?.user?.id,
+                userName: req?.user?.name,
+            });
+
+            if (req.headers['user-agent'].includes('iPhone')) {
+                res.redirect(`${process.env.OAUTH_IOS_FINAL_REDIRECT_URL}?token=${token}`);
+            } else {
+                res.redirect(`${process.env.OAUTH_WEB_FINAL_REDIRECT_URL}?token=${token}`);
+            }
+        },
+    );
+
+    return router;
+};

--- a/server/src/router/index.js
+++ b/server/src/router/index.js
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+import { OAuthRouter } from './OAuthRouter';
+
+export const IndexRouter = () => {
+    const router = Router();
+
+    router.use('/api/oauth', OAuthRouter());
+
+    return router;
+};

--- a/server/src/service/ActivityService.js
+++ b/server/src/service/ActivityService.js
@@ -1,6 +1,6 @@
-import { AbstractService } from './AbstractService';
+import { BaseService } from './BaseService';
 
-export class ActivityService extends AbstractService {
+export class ActivityService extends BaseService {
     static instance = null;
 
     static getInstance() {

--- a/server/src/service/BaseService.js
+++ b/server/src/service/BaseService.js
@@ -7,7 +7,7 @@ import { Invitation } from '../model/Invitation';
 import { List } from '../model/List';
 import { User } from '../model/User';
 
-export class AbstractService {
+export class BaseService {
     constructor() {
         this.activityRepository = getRepository(Activity);
         this.boardRepository = getRepository(Board);

--- a/server/src/service/BoardService.js
+++ b/server/src/service/BoardService.js
@@ -1,6 +1,6 @@
-import { AbstractService } from './AbstractService';
+import { BaseService } from './BaseService';
 
-export class BoardService extends AbstractService {
+export class BoardService extends BaseService {
     static instance = null;
 
     static getInstance() {

--- a/server/src/service/CardService.js
+++ b/server/src/service/CardService.js
@@ -1,6 +1,6 @@
-import { AbstractService } from './AbstractService';
+import { BaseService } from './BaseService';
 
-export class CardService extends AbstractService {
+export class CardService extends BaseService {
     static instance = null;
 
     static getInstance() {

--- a/server/src/service/CommentService.js
+++ b/server/src/service/CommentService.js
@@ -1,6 +1,6 @@
-import { AbstractService } from './AbstractService';
+import { BaseService } from './BaseService';
 
-export class CommentService extends AbstractService {
+export class CommentService extends BaseService {
     static instance = null;
 
     static getInstance() {

--- a/server/src/service/InvitationService.js
+++ b/server/src/service/InvitationService.js
@@ -1,6 +1,6 @@
-import { AbstractService } from './AbstractService';
+import { BaseService } from './BaseService';
 
-export class InvitationService extends AbstractService {
+export class InvitationService extends BaseService {
     static instance = null;
 
     static getInstance() {

--- a/server/src/service/ListService.js
+++ b/server/src/service/ListService.js
@@ -1,6 +1,6 @@
-import { AbstractService } from './AbstractService';
+import { BaseService } from './BaseService';
 
-export class ListService extends AbstractService {
+export class ListService extends BaseService {
     static instance = null;
 
     static getInstance() {

--- a/server/src/service/UserService.js
+++ b/server/src/service/UserService.js
@@ -1,6 +1,6 @@
-import { AbstractService } from './AbstractService';
+import { BaseService } from './BaseService';
 
-export class UserService extends AbstractService {
+export class UserService extends BaseService {
     static instance = null;
 
     static getInstance() {

--- a/server/test/common/util/JwtUtil.test.js
+++ b/server/test/common/util/JwtUtil.test.js
@@ -1,0 +1,64 @@
+import { decode } from 'jsonwebtoken';
+import { JwtUtil } from '../../../src/common/util/JwtUtil';
+
+const secret = 'secret';
+const jwtUtil = new JwtUtil(secret);
+
+describe('JwtUtil.generateAccessToken() Test', () => {
+    test('access token 생성 후 payload 비교', async () => {
+        // given
+        const payload = { id: 0 };
+
+        // when
+        const token = await jwtUtil.generateAccessToken(payload);
+
+        // then
+        const bearer = token.split(' ')[0];
+        const jwt = token.split(' ')[1];
+
+        expect(bearer).toEqual('Bearer');
+        expect(decode(jwt)?.id).toEqual(0);
+    });
+});
+
+describe('JwtUtil.validateAccessToken() Test', () => {
+    test('access token 생성 후 검증', async () => {
+        // given
+        const payload = { id: 0 };
+        const token = await jwtUtil.generateAccessToken(payload);
+
+        // when
+        const decoded = await jwtUtil.validateAccessToken(token);
+
+        // then
+        expect(decoded?.id).toEqual(0);
+    });
+
+    test('잘못된 secret으로 암호화된 access token 검증 실패', async () => {
+        // given
+        const token =
+            'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MCwiaWF0IjoxNTE2MjM5MDIyfQ.qwzCEHw1sJkXiV6fVGfasuDIrr0WYz78E3JdgC9AdoM';
+
+        try {
+            // when
+            const decoded = await jwtUtil.validateAccessToken(token);
+            fail();
+        } catch (error) {
+            // then
+            expect(error).toBeInstanceOf(Error);
+        }
+    });
+});
+
+describe('JwtUtil.matchBearer() Test', () => {
+    test('Bearer 매칭', async () => {
+        // given
+        const a = 'Bearer token';
+        const b = 'token';
+
+        // when
+        // then
+        expect(jwtUtil.matchBearer(a)).toBeTruthy();
+        expect(jwtUtil.matchBearer(b)).toBeFalsy();
+    });
+});


### PR DESCRIPTION
# 네이버 로그인 구현 완료

## 📎 해당 이슈

이슈 링크 (#21 )

## 🛠 구현 내용 

- 네이버 로그인 구현
    - Passport NaverStrategy 추가
    - Application에 initPassport 메서드 추가
    - JwtUtil 추가 및 테스트 작성
    - jsonwebtoken의 async/await wrapper 추가
    - OAuthRouter 추가
- ApplicationFactory 제거
    - 팩토리 패턴을 사용할 만큼 Application을 생성하는 로직이 복잡하지 않다
    - main에서 직접 초기화를 해주는 것이 직관적일 수 있다

## 🙋‍ 리뷰어 참고 사항 
- AbstractService.js -> BaseService.js, 멘토님의 피드백을 반영했습니다.
