### PR TITLE
보드 전체 조회 API 구현

### DIFF
--- a/server/src/router/BoardRouter.js
+++ b/server/src/router/BoardRouter.js
@@ -6,10 +6,9 @@ export const BoardRouter = () => {
 
     router.get('/', async (req, res) => {
         const boardService = BoardService.getInstance();
-        // TODO: jwt 추가 후, req.user에서 userId를 가져와야할 것
-        const userId = 1;
-        const data = await boardService.getBoardsByUserId(userId);
-        res.status(200).json({ data });
+        const { id } = req.user;
+        const data = await boardService.getBoardsByUserId(id);
+        res.status(200).json({ ...data });
     });
 
     return router;

--- a/server/src/router/BoardRouter.js
+++ b/server/src/router/BoardRouter.js
@@ -1,0 +1,16 @@
+import { Router } from 'express';
+import { BoardService } from '../service/BoardService';
+
+export const BoardRouter = () => {
+    const router = Router();
+
+    router.get('/', async (req, res) => {
+        const boardService = BoardService.getInstance();
+        // TODO: jwt 추가 후, req.user에서 userId를 가져와야할 것
+        const userId = 1;
+        const data = await boardService.getBoardsByUserId(userId);
+        res.status(200).json({ data });
+    });
+
+    return router;
+};

--- a/server/src/router/BoardRouter.js
+++ b/server/src/router/BoardRouter.js
@@ -8,7 +8,7 @@ export const BoardRouter = () => {
         const boardService = BoardService.getInstance();
         const { id } = req.user;
         const data = await boardService.getBoardsByUserId(id);
-        res.status(200).json({ ...data });
+        res.status(200).json(data);
     });
 
     return router;

--- a/server/src/router/index.js
+++ b/server/src/router/index.js
@@ -1,10 +1,13 @@
 import { Router } from 'express';
 import { OAuthRouter } from './OAuthRouter';
+import { BoardRouter } from './BoardRouter';
 
 export const IndexRouter = () => {
     const router = Router();
 
     router.use('/api/oauth', OAuthRouter());
+    // TODO: jwt 권한 확인 미들웨어 추가해야할 것
+    router.use('/api/board', BoardRouter());
 
     return router;
 };

--- a/server/src/router/index.js
+++ b/server/src/router/index.js
@@ -9,7 +9,7 @@ export const IndexRouter = () => {
 
     router.use('/api/oauth', OAuthRouter());
     router.use('/api/user', passport.authenticate('jwt', { session: false }), UserRouter());
-    router.use('/api/board', BoardRouter());
+    router.use('/api/board', passport.authenticate('jwt', { session: false }), BoardRouter());
 
     return router;
 };

--- a/server/src/service/BoardService.js
+++ b/server/src/service/BoardService.js
@@ -1,3 +1,4 @@
+import { Transactional } from 'typeorm-transactional-cls-hooked';
 import { BaseService } from './BaseService';
 
 export class BoardService extends BaseService {
@@ -9,5 +10,33 @@ export class BoardService extends BaseService {
         }
 
         return BoardService.instance;
+    }
+
+    async getMyBoards(id) {
+        const boards = await this.boardRepository.find({
+            select: ['id', 'title'],
+            where: { creator: id },
+        });
+        return boards;
+    }
+
+    async getInvitedBoards(id) {
+        const boards = await this.boardRepository
+            .createQueryBuilder('board')
+            .select('board.id')
+            .addSelect('board.title')
+            .innerJoin('board.invitations', 'invitation', 'invitation.user=:userId', { userId: id })
+            .getMany();
+        return boards;
+    }
+
+    @Transactional()
+    async getBoardsByUserId(userId) {
+        const data = {};
+
+        data.myBoards = await this.getMyBoards(userId);
+        data.invitedBoards = await this.getInvitedBoards(userId);
+
+        return data;
     }
 }

--- a/server/src/service/BoardService.js
+++ b/server/src/service/BoardService.js
@@ -25,18 +25,18 @@ export class BoardService extends BaseService {
             .createQueryBuilder('board')
             .select('board.id')
             .addSelect('board.title')
-            .innerJoin('board.invitations', 'invitation', 'invitation.user=:userId', { userId: id })
+            .innerJoin('board.invitations', 'invitation', 'invitation.user_id=:userId', {
+                userId: id,
+            })
             .getMany();
         return boards;
     }
 
     @Transactional()
     async getBoardsByUserId(userId) {
-        const data = {};
+        const promises = [this.getMyBoards(userId), this.getInvitedBoards(userId)];
+        const [myBoards, invitedBoards] = await Promise.all(promises);
 
-        data.myBoards = await this.getMyBoards(userId);
-        data.invitedBoards = await this.getInvitedBoards(userId);
-
-        return data;
+        return { myBoards, invitedBoards };
     }
 }

--- a/server/test/router/BoardRouter.test.js
+++ b/server/test/router/BoardRouter.test.js
@@ -1,0 +1,84 @@
+import request from 'supertest';
+import { getRepository } from 'typeorm';
+import { Application } from '../../src/Application';
+import { JwtUtil } from '../../src/common/util/JwtUtil';
+import { Board } from '../../src/model/Board';
+import { Invitation } from '../../src/model/Invitation';
+import { User } from '../../src/model/User';
+
+describe('Board API Test', () => {
+    let app = null;
+    let jwtUtil = null;
+
+    beforeAll(async () => {
+        const newApp = new Application();
+        await newApp.initialize();
+        app = newApp;
+        jwtUtil = JwtUtil.getInstance();
+    });
+
+    test('GET /api/board를 호출할 때, Authorization header가 없으면 400을 리턴한다.', async () => {
+        // given
+        // when
+        const response = await request(app.httpServer).get('/api/board').set({
+            'Content-Type': 'application/json',
+        });
+
+        // then
+        expect(response.status).toEqual(400);
+    });
+
+    test('GET /api/board를 호출할 때, 권한이 없으면 401을 리턴한다.', async () => {
+        // given
+        const token = 'Bearer fakeToken';
+
+        // when
+        const response = await request(app.httpServer).get('/api/board').set({
+            Authorization: token,
+            'Content-Type': 'application/json',
+        });
+
+        // then
+        expect(response.status).toEqual(401);
+    });
+
+    test('GET /api/board가 정상적으로 호출되었을 때, 200을 리턴한다.', async () => {
+        // given
+        const user1 = { name: 'user1', socialId: '1234', profileImageUrl: 'image' };
+        const user2 = { name: 'user2', socialId: '1244', profileImageUrl: 'image' };
+
+        const userRepository = getRepository(User);
+        const createUser1 = await userRepository.create(user1);
+        const createUser2 = await userRepository.create(user2);
+        const [createdUser1, createdUser2] = await userRepository.save([createUser1, createUser2]);
+
+        const token = await jwtUtil.generateAccessToken({
+            userId: createdUser2.id,
+            username: createdUser2.name,
+        });
+
+        const boardRepository = getRepository(Board);
+        const board1 = { id: 1, title: 'board1', creator: createdUser1.id };
+        const board2 = { id: 2, title: 'board2', creator: createdUser2.id };
+        const createBoard1 = await boardRepository.create(board1);
+        const createBoard2 = await boardRepository.create(board2);
+        const [createdBoard1] = await boardRepository.save([createBoard1, createBoard2]);
+
+        const invitationRepository = getRepository(Invitation);
+        const invitedBoard = { user: createdUser2.id, board: createdBoard1.id };
+        const createInvitedBoard = await invitationRepository.create(invitedBoard);
+        await invitationRepository.save(createInvitedBoard);
+
+        // when
+        const response = await request(app.httpServer).get('/api/board').set({
+            Authorization: token,
+            'Content-Type': 'application/json',
+        });
+
+        // then
+        expect(response.status).toEqual(200);
+        const { myBoards, invitedBoards } = response.body;
+        expect(myBoards).toHaveLength(1);
+        expect(invitedBoards).toHaveLength(1);
+    });
+});


### PR DESCRIPTION
# 보드 전체 조회 API 구현

## 📎 해당 이슈

이슈 링크 (#17 )

## 🛠 구현 내용 

- `GET /api/board`의 요청을 처리하는 API 구현
- 요청 처리를 위한 Service, Router 추가

## 🙋‍ 리뷰어 참고 사항 

- 테스트 할때마다 오류가 나서 아직 테스트 코드를 구현하지 못하였습니다.. 좀 더 공부하고 추가하겠습니다..테스트 코드 작성 많이 어렵네요ㅠ
