### PR TITLE
CardCell swipe 동작 추가

### DIFF
--- a/iOS/AreUDone/AreUDone/CalendarScene/View/CardCollectionView/CardCollectionView.swift
+++ b/iOS/AreUDone/AreUDone/CalendarScene/View/CardCollectionView/CardCollectionView.swift
@@ -44,16 +44,16 @@ final class CardCollectionView: UICollectionView {
     collectionViewLayout = layout
   }
   
-  func resetCellOffset(without cell: CardCollectionViewCell? = nil) {
+  func resetVisibleCellOffset(without cell: CardCollectionViewCell? = nil) {
     guard var cells = visibleCells as? [CardCollectionViewCell] else { return }
     if let cell = cell {
-      cells.removeAll { visibleCell -> Bool in
-        visibleCell == cell
+      cells.removeAll {
+        $0 == cell
       }
     }
     
-    cells.forEach({ visibleCell in
-      visibleCell.resetOffset()
+    cells.forEach({
+      $0.resetOffset()
     })
   }
 }

--- a/iOS/AreUDone/AreUDone/CalendarScene/View/CardCollectionView/CardCollectionView.swift
+++ b/iOS/AreUDone/AreUDone/CalendarScene/View/CardCollectionView/CardCollectionView.swift
@@ -43,4 +43,17 @@ final class CardCollectionView: UICollectionView {
     
     collectionViewLayout = layout
   }
+  
+  func resetCellOffset(without cell: CardCollectionViewCell? = nil) {
+    guard var cells = visibleCells as? [CardCollectionViewCell] else { return }
+    if let cell = cell {
+      cells.removeAll { visibleCell -> Bool in
+        visibleCell == cell
+      }
+    }
+    
+    cells.forEach({ visibleCell in
+      visibleCell.resetOffset()
+    })
+  }
 }

--- a/iOS/AreUDone/AreUDone/CalendarScene/View/CardCollectionView/CardCollectionView.swift
+++ b/iOS/AreUDone/AreUDone/CalendarScene/View/CardCollectionView/CardCollectionView.swift
@@ -45,15 +45,12 @@ final class CardCollectionView: UICollectionView {
   }
   
   func resetVisibleCellOffset(without cell: CardCollectionViewCell? = nil) {
-    guard var cells = visibleCells as? [CardCollectionViewCell] else { return }
-    if let cell = cell {
-      cells.removeAll {
-        $0 == cell
-      }
-    }
-    
+    guard let cells = visibleCells as? [CardCollectionViewCell] else { return }
+
     cells.forEach({
-      $0.resetOffset()
+      if $0 != cell {
+        $0.resetOffset()
+      }
     })
   }
 }

--- a/iOS/AreUDone/AreUDone/CalendarScene/View/CardCollectionView/CardCollectionViewCell.swift
+++ b/iOS/AreUDone/AreUDone/CalendarScene/View/CardCollectionView/CardCollectionViewCell.swift
@@ -71,7 +71,7 @@ class CardCollectionViewCell: UICollectionViewCell, Reusable {
   }
   
   func resetOffset() {
-    UIView.animate(withDuration: 0.3) {
+    UIView.animate(withDuration: 0.5) {
       self.scrollView.contentOffset.x = 0
     }
   }
@@ -105,15 +105,14 @@ private extension CardCollectionViewCell {
   func configureStackView() {
     scrollView.addSubview(stackView)
     stackView.translatesAutoresizingMaskIntoConstraints = false
-    if let superViewOfStackView = stackView.superview {
-      NSLayoutConstraint.activate([
-        stackView.heightAnchor.constraint(equalTo: scrollView.heightAnchor),
-        stackView.topAnchor.constraint(equalTo: superViewOfStackView.topAnchor),
-        stackView.bottomAnchor.constraint(equalTo: superViewOfStackView.bottomAnchor),
-        stackView.leadingAnchor.constraint(equalTo: superViewOfStackView.leadingAnchor),
-        stackView.trailingAnchor.constraint(equalTo: superViewOfStackView.trailingAnchor),
-      ])
-    }
+    
+    NSLayoutConstraint.activate([
+      stackView.heightAnchor.constraint(equalTo: scrollView.heightAnchor),
+      stackView.topAnchor.constraint(equalTo: scrollView.topAnchor),
+      stackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+      stackView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+      stackView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
+    ])
   }
   
   func configureCardContentView() {
@@ -155,7 +154,13 @@ extension CardCollectionViewCell {
 
 extension CardCollectionViewCell: UIScrollViewDelegate {
   func scrollViewDidScroll(_ scrollView: UIScrollView) {
-    scrollView.backgroundColor = scrollView.contentOffset.x <= 0 ? .clear : .systemRed
-    delegate?.resetCellOffset(without: self)
+    if scrollView.contentOffset.x <= 0 {
+      scrollView.bounces = false
+      scrollView.contentOffset.x = 0
+    } else {
+      scrollView.bounces = true
+      delegate?.resetCellOffset(without: self)
+    }
   }
+
 }

--- a/iOS/AreUDone/AreUDone/CalendarScene/View/CardCollectionView/CardCollectionViewCell.swift
+++ b/iOS/AreUDone/AreUDone/CalendarScene/View/CardCollectionView/CardCollectionViewCell.swift
@@ -9,6 +9,7 @@ import UIKit
 
 protocol CardCellDelegate {
   func delete(cardCell: CardCollectionViewCell)
+  func resetCellOffset(without cell: CardCollectionViewCell)
 }
 
 class CardCollectionViewCell: UICollectionViewCell, Reusable {
@@ -67,6 +68,12 @@ class CardCollectionViewCell: UICollectionViewCell, Reusable {
   
   func updateCell(with card: Card) {
     cardContentView.updateContentView(with: card)
+  }
+  
+  func resetOffset() {
+    UIView.animate(withDuration: 0.3) {
+      self.scrollView.contentOffset.x = 0
+    }
   }
 }
 
@@ -149,5 +156,6 @@ extension CardCollectionViewCell {
 extension CardCollectionViewCell: UIScrollViewDelegate {
   func scrollViewDidScroll(_ scrollView: UIScrollView) {
     scrollView.backgroundColor = scrollView.contentOffset.x <= 0 ? .clear : .systemRed
+    delegate?.resetCellOffset(without: self)
   }
 }

--- a/iOS/AreUDone/AreUDone/CalendarScene/View/Controller/CalendarViewController.swift
+++ b/iOS/AreUDone/AreUDone/CalendarScene/View/Controller/CalendarViewController.swift
@@ -133,7 +133,7 @@ extension CalendarViewController: CardCellDelegate {
   }
   
   func resetCellOffset(without cell: CardCollectionViewCell) {
-    cardCollectionView.resetCellOffset(without: cell)
+    cardCollectionView.resetVisibleCellOffset(without: cell)
   }
 }
 
@@ -142,6 +142,6 @@ extension CalendarViewController: CardCellDelegate {
 
 extension CalendarViewController: UICollectionViewDelegate {
   func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
-    cardCollectionView.resetCellOffset()
+    cardCollectionView.resetVisibleCellOffset()
   }
 }

--- a/iOS/AreUDone/AreUDone/CalendarScene/View/Controller/CalendarViewController.swift
+++ b/iOS/AreUDone/AreUDone/CalendarScene/View/Controller/CalendarViewController.swift
@@ -24,7 +24,7 @@ final class CalendarViewController: UIViewController {
   
   @IBOutlet private weak var dateLabel: DateLabel!
   @IBOutlet private weak var currentDateLabel: UILabel!
-  @IBOutlet weak var cardCollectionView: UICollectionView!
+  @IBOutlet weak var cardCollectionView: CardCollectionView!
   
   
   // MARK: - Initializer
@@ -45,10 +45,7 @@ final class CalendarViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
     bindUI()
-    viewModel.fetchInitializeDailyCards()
-    configureDateLabelTapGesture()
-    
-    navigationController?.navigationBar.isHidden = true
+    configure()
   }
 }
 
@@ -58,6 +55,13 @@ final class CalendarViewController: UIViewController {
 private extension CalendarViewController {
   
   // MARK:- Method
+  
+  func configure() {
+    configureDateLabelTapGesture()
+    cardCollectionView.delegate = self
+    viewModel.fetchInitializeDailyCards()
+    navigationController?.navigationBar.isHidden = true
+  }
   
   func configureDateLabelTapGesture() {
     let tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(dateLabelDidTapped))
@@ -88,7 +92,7 @@ private extension CalendarViewController {
       }
     }
   }
-
+  
   func configureDataSource() -> DataSource {
     let dataSource = DataSource(
       collectionView: cardCollectionView
@@ -106,7 +110,7 @@ private extension CalendarViewController {
   
   func updateSnapshot(with item: Cards, animatingDifferences: Bool = true) {
     var snapshot = Snapshot()
-
+    
     snapshot.appendSections([""])
     snapshot.appendItems(item.cards)
     
@@ -115,9 +119,10 @@ private extension CalendarViewController {
 }
 
 
-// MARK:- Extension
+// MARK:- Extension CardCellDelegate
 
 extension CalendarViewController: CardCellDelegate {
+  
   func delete(cardCell: CardCollectionViewCell) {
     if let indexPath = cardCollectionView.indexPath(for: cardCell),
        let item = dataSource.itemIdentifier(for: indexPath) {
@@ -125,5 +130,18 @@ extension CalendarViewController: CardCellDelegate {
       snapshot.deleteItems([item])
       
     }
+  }
+  
+  func resetCellOffset(without cell: CardCollectionViewCell) {
+    cardCollectionView.resetCellOffset(without: cell)
+  }
+}
+
+
+// MARK:- Extension UICollectionViewDelegate
+
+extension CalendarViewController: UICollectionViewDelegate {
+  func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+    cardCollectionView.resetCellOffset()
   }
 }


### PR DESCRIPTION
# CardCell swipe 동작 추가

## 📎 해당 이슈
#82 

## 🛠 구현 내용 

- cell이 swipe된 상태에서 다른 cell을 swipe하면 기존 cell의 swipe가 취소된다.
- cell이 swipe된 상태에서 collectionView가 scroll되면 기존 cell의 swipe가 취소된다.

## 🙋‍ 리뷰어 참고 사항 
Cell의 resetOffset을 관리하는 메서드를 CardCollectionView 안에 구현했습니다.
다른 Cell을 swipe할 때와 collectionView를 scroll할 때 재사용하기 위해서 메서드를 작성했습니다.