### PR TITLE
메인 페이지의 sidebar 컴포넌트 생성

### DIFF
--- a/client/src/components/mainPage/Board.js
+++ b/client/src/components/mainPage/Board.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const BoardTitle = styled.li`
+    padding: 8px 0;
+    margin-bottom: 2px;
+    border: ${(props) => props.theme.border};
+    font-size: 18px;
+    font-weight: 700;
+    text-align: center;
+    cursor: pointer;
+`;
+
+const Board = ({ title }) => {
+    return <BoardTitle>{title}</BoardTitle>;
+};
+
+export default Board;

--- a/client/src/components/mainPage/Board.js
+++ b/client/src/components/mainPage/Board.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
 const BoardTitle = styled.li`
@@ -11,8 +12,12 @@ const BoardTitle = styled.li`
     cursor: pointer;
 `;
 
-const Board = ({ title }) => {
-    return <BoardTitle>{title}</BoardTitle>;
+const Board = ({ id, title }) => {
+    return (
+        <Link to={`/board/${id}`}>
+            <BoardTitle>{title}</BoardTitle>
+        </Link>
+    );
 };
 
 export default Board;

--- a/client/src/components/mainPage/SideBar.js
+++ b/client/src/components/mainPage/SideBar.js
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import styled from 'styled-components';
+import { BoardsStatusContext } from '../../context/BoardsContext';
 import Board from './Board';
 
 const Wrapper = styled.div`
@@ -30,18 +31,22 @@ const AddBoardButton = styled.button`
 `;
 
 const SideBar = () => {
+    const { myBoards, invitedBoards } = useContext(BoardsStatusContext);
+
     return (
         <Wrapper>
             <BoardTitle>내가 만든 보드</BoardTitle>
             <BoardWrapper>
-                <Board title="보드 1" />
-                <Board title="보드 2" />
+                {myBoards.map((board) => {
+                    return <Board key={board.id} id={board.id} title={board.title} />;
+                })}
             </BoardWrapper>
             <AddBoardButton>+ 보드 추가하기</AddBoardButton>
             <BoardTitle>초대 받은 보드</BoardTitle>
             <BoardWrapper>
-                <Board title="보드 3" />
-                <Board title="보드 4" />
+                {invitedBoards.map((board) => {
+                    return <Board key={board.id} id={board.id} title={board.title} />;
+                })}
             </BoardWrapper>
         </Wrapper>
     );

--- a/client/src/components/mainPage/SideBar.js
+++ b/client/src/components/mainPage/SideBar.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import styled from 'styled-components';
+import Board from './Board';
+
+const Wrapper = styled.div`
+    width: 20%;
+    padding: 5px;
+
+    @media ${(props) => props.theme.sideBar} {
+        display: none;
+    }
+`;
+
+const BoardTitle = styled.div`
+    margin-top: 40px;
+    margin-bottom: 15px;
+    font-size: 20px;
+    font-weight: 700;
+`;
+
+const BoardWrapper = styled.ul``;
+
+const AddBoardButton = styled.button`
+    width: 100%;
+    padding: 3px 0;
+    border: ${(props) => props.theme.border};
+    font-size: 18px;
+    font-weight: 700;
+    text-align: center;
+`;
+
+const SideBar = () => {
+    return (
+        <Wrapper>
+            <BoardTitle>내가 만든 보드</BoardTitle>
+            <BoardWrapper>
+                <Board title="보드 1" />
+                <Board title="보드 2" />
+            </BoardWrapper>
+            <AddBoardButton>+ 보드 추가하기</AddBoardButton>
+            <BoardTitle>초대 받은 보드</BoardTitle>
+            <BoardWrapper>
+                <Board title="보드 3" />
+                <Board title="보드 4" />
+            </BoardWrapper>
+        </Wrapper>
+    );
+};
+
+export default SideBar;

--- a/client/src/components/mainPage/index.js
+++ b/client/src/components/mainPage/index.js
@@ -1,7 +1,18 @@
 import React from 'react';
+import styled from 'styled-components';
+import SideBar from './SideBar';
+
+const Wrapper = styled.div`
+    width: 1100px;
+    margin: 0 auto;
+`;
 
 const Main = () => {
-    return <div>메인 페이지</div>;
+    return (
+        <Wrapper>
+            <SideBar />
+        </Wrapper>
+    );
 };
 
 export default Main;

--- a/client/src/components/mainPage/index.js
+++ b/client/src/components/mainPage/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import BoardsProvider from '../provider/BoardsProvider';
 import SideBar from './SideBar';
 
 const Wrapper = styled.div`
@@ -10,7 +11,9 @@ const Wrapper = styled.div`
 const Main = () => {
     return (
         <Wrapper>
-            <SideBar />
+            <BoardsProvider>
+                <SideBar />
+            </BoardsProvider>
         </Wrapper>
     );
 };

--- a/client/src/components/provider/BoardsProvider.js
+++ b/client/src/components/provider/BoardsProvider.js
@@ -1,0 +1,36 @@
+import React, { useEffect, useReducer } from 'react';
+import {
+    initBoards,
+    BoardsReducer,
+    BoardsStatusContext,
+    BoardsDispatchContext,
+} from '../../context/BoardsContext';
+import { getBoards } from '../../utils/boardRequest';
+
+export default ({ children }) => {
+    const [state, dispatch] = useReducer(BoardsReducer, initBoards);
+
+    useEffect(async () => {
+        const { status, data } = await getBoards();
+
+        switch (status) {
+            case 200:
+                dispatch({ type: 'GET_BOARDS', data });
+                break;
+            case 400:
+            case 401:
+                window.location.href = '/login';
+                break;
+            default:
+                throw new Error(`Unhandled status type : ${status}`);
+        }
+    }, []);
+
+    return (
+        <BoardsStatusContext.Provider value={state}>
+            <BoardsDispatchContext.Provider value={dispatch}>
+                {children}
+            </BoardsDispatchContext.Provider>
+        </BoardsStatusContext.Provider>
+    );
+};

--- a/client/src/context/BoardsContext.js
+++ b/client/src/context/BoardsContext.js
@@ -1,0 +1,23 @@
+import { createContext } from 'react';
+
+export const initBoards = {
+    myBoards: [],
+    invitedBoards: [],
+};
+
+export const BoardsReducer = (state, action) => {
+    switch (action.type) {
+        case 'GET_BOARDS': {
+            const boards = action.data;
+            return {
+                ...state,
+                ...boards,
+            };
+        }
+        default:
+            throw new Error(`Unhandled action type: ${action.type}`);
+    }
+};
+
+export const BoardsStatusContext = createContext();
+export const BoardsDispatchContext = createContext();

--- a/client/src/utils/api.js
+++ b/client/src/utils/api.js
@@ -9,15 +9,17 @@ import axios from 'axios';
 
 const request = async (config) => {
     try {
+        const token = localStorage.getItem('jwt');
+
         const res = await axios({
             headers: {
-                Authorization: config.token,
+                Authorization: token,
                 'Content-Type': 'application/json',
             },
             ...config,
-            url: process.env.BASE_URL + config.url,
+            url: process.env.REACT_APP_BASE_URL + config.url,
         });
-        return { status: res.status, ...res.data };
+        return { status: res.status, data: res.data };
     } catch ({ response }) {
         return { status: response.status };
     }

--- a/client/src/utils/boardRequest.js
+++ b/client/src/utils/boardRequest.js
@@ -1,0 +1,12 @@
+import request from './api';
+
+// eslint-disable-next-line import/prefer-default-export
+export const getBoards = async () => {
+    const config = {
+        url: '/api/board',
+        method: 'GET',
+    };
+    const response = await request(config);
+
+    return response;
+};


### PR DESCRIPTION
# 메인 페이지의 sidebar 컴포넌트 생성

## 📎 해당 이슈

이슈 링크 (#67)

## 🛠 구현 내용 

- sidebar 컴포넌트 생성
- `GET /api/board` 요청 데이터로 보드 리스트 생성
- 상태 관리를 위하여 context, provider 사용

## 🙋‍ 리뷰어 참고 사항 
![image](https://user-images.githubusercontent.com/49746644/100199619-c84f8880-2f40-11eb-896a-d3f8475f88a9.png)
디자인은 대충 요로코롬 작업해봤습니다.
보드 추가 클릭 이벤트 작업은 보드 추가 모달 컴포넌트가 생성되면 추가하겠습니다:D
