### PR TITLE
일별 카드 개수 조회 API 데이터 연동

### DIFF
--- a/client/src/components/mainPage/CalendarDate.js
+++ b/client/src/components/mainPage/CalendarDate.js
@@ -32,8 +32,17 @@ const CardCountWrapper = styled.div`
     margin-top: 10px;
     padding: 5px 8px;
     border-radius: ${(props) => props.theme.radiusSmall};
-    background-color: #ff0000;
     color: ${(props) => props.theme.whiteColor};
+
+    &.manyCard {
+        background-color: ${(props) => props.theme.manyColor};
+    }
+    &.someCard {
+        background-color: ${(props) => props.theme.someColor};
+    }
+    &.littleCard {
+        background-color: ${(props) => props.theme.littleColor};
+    }
 
     @media ${(props) => props.theme.sideBar} {
         padding: 2px;
@@ -51,11 +60,19 @@ const CardCount = styled.div`
     }
 `;
 
+const getCardBackground = (count) => {
+    if (count > 10) return 'manyCard';
+    if (count > 5) return 'someCard';
+    return 'littleCard';
+};
+
 const Date = ({ className, onClick, date, count }) => {
+    const cardBackground = getCardBackground(count);
+
     return (
         <DateWrapper className={className} onClick={() => onClick(date)}>
             <DateNumber>{date.format('D')}</DateNumber>
-            <CardCountWrapper count={count}>
+            <CardCountWrapper className={cardBackground} count={count}>
                 <BsCardChecklist size={24} />
                 <CardCount>{count || 0}</CardCount>
             </CardCountWrapper>

--- a/client/src/components/mainPage/CalendarHeader.js
+++ b/client/src/components/mainPage/CalendarHeader.js
@@ -2,6 +2,7 @@ import React, { useContext } from 'react';
 import styled from 'styled-components';
 import { MdChevronLeft, MdChevronRight } from 'react-icons/md';
 import { CalendarDispatchContext, CalendarStatusContext } from '../../context/CalendarContext';
+import { getCardCount } from '../../utils/cardRequest';
 
 const HeaderWrapper = styled.div`
     display: flex;
@@ -25,10 +26,14 @@ const CalendarHeader = () => {
     const { selectedDate } = useContext(CalendarStatusContext);
     const calendarDispatch = useContext(CalendarDispatchContext);
 
-    const onClickMoveMonth = (next) => {
+    const onClickMoveMonth = async (next) => {
         const changeDate = selectedDate.clone();
         const date = next ? changeDate.add(1, 'month') : changeDate.subtract(1, 'month');
-        calendarDispatch({ type: 'CHANGE_MONTH', date });
+
+        const startDate = date.clone().startOf('month').startOf('week').format('YYYY-MM-DD');
+        const endDate = date.clone().endOf('month').endOf('week').format('YYYY-MM-DD');
+        const { data } = await getCardCount({ startDate, endDate });
+        calendarDispatch({ type: 'CHANGE_MONTH', date, cardCount: data.cardCounts });
     };
 
     return (

--- a/client/src/components/provider/CalendarProvider.js
+++ b/client/src/components/provider/CalendarProvider.js
@@ -1,13 +1,22 @@
-import React, { useReducer } from 'react';
+import React, { useEffect, useReducer } from 'react';
 import {
     initCalendar,
     CalendarReducer,
     CalendarStatusContext,
     CalendarDispatchContext,
 } from '../../context/CalendarContext';
+import { getCardCount } from '../../utils/cardRequest';
 
 export default ({ children }) => {
     const [state, dispatch] = useReducer(CalendarReducer, initCalendar);
+
+    useEffect(async () => {
+        const startDate = state.today.clone().startOf('month').startOf('week').format('YYYY-MM-DD');
+        const endDate = state.today.clone().endOf('month').endOf('week').format('YYYY-MM-DD');
+        const { data } = await getCardCount({ startDate, endDate });
+
+        dispatch({ type: 'GET_INIT_CARD_COUNT', cardCount: data.cardCounts });
+    });
 
     return (
         <CalendarStatusContext.Provider value={state}>

--- a/client/src/components/provider/CalendarProvider.js
+++ b/client/src/components/provider/CalendarProvider.js
@@ -16,7 +16,7 @@ export default ({ children }) => {
         const { data } = await getCardCount({ startDate, endDate });
 
         dispatch({ type: 'GET_INIT_CARD_COUNT', cardCount: data.cardCounts });
-    });
+    }, []);
 
     return (
         <CalendarStatusContext.Provider value={state}>

--- a/client/src/context/CalendarContext.js
+++ b/client/src/context/CalendarContext.js
@@ -4,15 +4,24 @@ import moment from 'moment';
 export const initCalendar = {
     today: moment(),
     selectedDate: moment(),
+    cardCount: [],
 };
 
 export const CalendarReducer = (state, action) => {
     switch (action.type) {
+        case 'GET_INIT_CARD_COUNT': {
+            const { cardCount } = action;
+            return {
+                ...state,
+                cardCount,
+            };
+        }
         case 'CHANGE_MONTH': {
-            const { date } = action;
+            const { date, cardCount } = action;
             return {
                 ...state,
                 selectedDate: date.clone(),
+                cardCount,
             };
         }
         case 'CHANGE_SELECTED_DATE': {

--- a/client/src/styles/theme.js
+++ b/client/src/styles/theme.js
@@ -17,6 +17,9 @@ const colors = {
     darkgrayColor: '#586069',
     lightGrayColor: '#c7c7c7',
     lightRedColor: '#f76e7c',
+    manyColor: '#e0098b',
+    someColor: '#f73fae',
+    littleColor: '#fa88cd',
 };
 
 // 자주 사용하는 css style

--- a/client/src/utils/cardRequest.js
+++ b/client/src/utils/cardRequest.js
@@ -1,0 +1,12 @@
+import request from './api';
+
+// eslint-disable-next-line import/prefer-default-export
+export const getCardCount = async ({ startDate, endDate }) => {
+    const config = {
+        url: `/api/card/count?q=startdate:${startDate} enddate:${endDate}`,
+        method: 'GET',
+    };
+    const response = await request(config);
+
+    return response;
+};


### PR DESCRIPTION
# 일별 카드 개수 조회 API 연동

## 📎 해당 이슈

이슈 링크 (#107 )

## 🛠 구현 내용 

- 달력 이동시, 일별 카드 개수 조회 API로 데이터를 요청하도록 이벤트 추가
- API 요청으로 받은 데이터를 기반으로 달력에 일별 카드 개수 표시
- 카드 개수별로 카드 개수 컴포넌트의 배경색을 다르게 구현

## 🙋‍ 리뷰어 참고 사항 
![image](https://user-images.githubusercontent.com/49746644/100979348-fce9c280-3586-11eb-988d-7a5377ecc574.png)


코드 리팩토링은 천천히 하겠읍니다..
