### PR TITLE
일별 카드 개수 조회 API 오류 수정

### DIFF
--- a/server/src/service/CardService.js
+++ b/server/src/service/CardService.js
@@ -35,6 +35,9 @@ export class CardService extends BaseService {
         const boardService = BoardService.getInstance();
 
         const boardIds = await boardService.getBoardIdsByUserId(userId);
+
+        if (boardIds.length === 0) return [];
+
         const config = { startDate, endDate, boardIds };
 
         if (member === 'me') {

--- a/server/test/router/CardRouter.test.js
+++ b/server/test/router/CardRouter.test.js
@@ -177,13 +177,11 @@ describe('Board API Test', () => {
             });
 
             const board1 = em.create(Board, {
-                id: 1,
                 title: 'board1',
                 creator: user1,
                 color: '#000000',
             });
             const board2 = em.create(Board, {
-                id: 2,
                 title: 'board2',
                 creator: user2,
                 color: '#000000',

--- a/server/test/service/CardService.test.js
+++ b/server/test/service/CardService.test.js
@@ -24,8 +24,32 @@ describe('Card Service Test', () => {
 
     beforeEach(async () => {});
 
+    test('정상적인 사용자가 카드를 조회할 때, 보드가 없으면 빈 배열 반환', async () => {
+        await TestTransactionDelegate.transaction(async () => {
+            // given
+            const em = getEntityManagerOrTransactionManager('default');
+            const user1 = em.create(User, {
+                name: 'user1',
+                socialId: '1234',
+                profileImageUrl: 'image',
+            });
+            await em.save(user1);
+
+            // when
+            const cardService = CardService.getInstance();
+            const cardCountList = await cardService.getCardCountByPeriod({
+                startDate: '2020-07-01',
+                endDate: '2020-07-31',
+                userId: user1.id,
+            });
+
+            // then
+            const data = cardCountList;
+            expect(data).toEqual([]);
+        });
+    });
+
     test('정상적인 사용자가 startDate, endDate 기간동안의 모든 카드 조회', async () => {
-        const cardRepository = getRepository(Card);
         await TestTransactionDelegate.transaction(async () => {
             // given
             const em = getEntityManagerOrTransactionManager('default');


### PR DESCRIPTION
# 일별 카드 개수 조회 API 오류 수정

## 📎 해당 이슈

이슈 링크 (#155 )

## 🛠 구현 내용 

- 로그인한 유저가 가진 보드 정보가 존재하지 않을 때, 빈 배열을 반환하도록 구현

## 🙋‍ 리뷰어 참고 사항 

생성하거나 초대된 보드가 존재하지 않을 때, boardsId가 빈 배열이고 이 빈 배열을 쿼리문에 삽입하려하니 IN() 구문에서 쿼리 구문 에러가 발생하더라구요..
그래서 보드가 존재하지 않을 때, 빈 배열을 응답해주어야할지, 에러 코드를 응답해주어야할지 고민하다가..
보드가 존재하지 않는 것이 요청을 처리하는데 있어 에러가 발생한 것이 아니라고 생각하여 상태 코드 200에 빈 배열을 응답하도록 구현하였습니다.
다른분들은 생성하거나 초대된 보드가 존재하지 않을 때, 어떤 응답을 해주어야 하는지에 대해 어떻게 생각하시나요?-?
