### PR TITLE
카드 수정 API 구현

### DIFF
--- a/server/src/common/error/ConflictError.js
+++ b/server/src/common/error/ConflictError.js
@@ -1,0 +1,8 @@
+import { BusinessError } from './BusinessError';
+import { ErrorCode } from './ErrorCode';
+
+export class ConflictError extends BusinessError {
+    constructor(message) {
+        super(ErrorCode.CONFLICT, message);
+    }
+}

--- a/server/src/common/error/ErrorCode.js
+++ b/server/src/common/error/ErrorCode.js
@@ -5,6 +5,7 @@ const ErrorCode = {
     FORBIDDEN: { code: 1003, httpStatusCode: 403, message: 'Forbidden' },
     BAD_REQUEST: { code: 1004, httpStatusCode: 400, message: 'Bad Request' },
     VALIDATION_ERROR: { code: 1005, httpStatusCode: 400, message: 'Validation error occurs' },
+    CONFLICT: { code: 1006, httpStatusCode: 409, message: 'conflict' },
 };
 
 export { ErrorCode };

--- a/server/src/common/util/validator.js
+++ b/server/src/common/util/validator.js
@@ -1,7 +1,7 @@
 import { plainToClass } from 'class-transformer';
 import { validateOrReject } from 'class-validator';
 
-export const validator = async (DtoClass, Object, groups) => {
+export const validator = async (DtoClass, Object, groups = []) => {
     const classObject = plainToClass(DtoClass, Object);
     await validateOrReject(classObject, { groups });
 };

--- a/server/src/dao/CustomBoardRepository.js
+++ b/server/src/dao/CustomBoardRepository.js
@@ -28,4 +28,15 @@ export class CustomBoardRepository extends BaseRepository {
 
         return boardIds;
     }
+
+    async checkAccess({ boardId, userId }) {
+        const isAuth = await this.createQueryBuilder('board')
+            .leftJoin('board.invitations', 'invitation')
+            .where('board.id=:boardId', { boardId })
+            .andWhere('board.creator_id=:userId', { userId })
+            .orWhere('invitation.user_id=:userId', { userId })
+            .getMany();
+
+        return isAuth.length !== 0;
+    }
 }

--- a/server/src/dao/CustomBoardRepository.js
+++ b/server/src/dao/CustomBoardRepository.js
@@ -43,8 +43,7 @@ export class CustomBoardRepository extends BaseRepository {
         const isAuth = await this.createQueryBuilder('board')
             .leftJoin('board.invitations', 'invitation')
             .where('board.id=:boardId', { boardId })
-            .andWhere('board.creator_id=:userId', { userId })
-            .orWhere('invitation.user_id=:userId', { userId })
+            .andWhere('(board.creator_id=:userId OR invitation.user_id=:userId)', { userId })
             .getMany();
 
         return isAuth.length !== 0;

--- a/server/src/dao/CustomBoardRepository.js
+++ b/server/src/dao/CustomBoardRepository.js
@@ -29,7 +29,17 @@ export class CustomBoardRepository extends BaseRepository {
         return boardIds;
     }
 
-    async checkAccess({ boardId, userId }) {
+    async findBoardByCardId(cardId) {
+        const board = await this.createQueryBuilder('board')
+            .innerJoin('board.lists', 'list')
+            .innerJoin('list.cards', 'card')
+            .where('card.id=:cardId', { cardId })
+            .getOne();
+
+        return board;
+    }
+
+    async existUserByBoardId({ boardId, userId }) {
         const isAuth = await this.createQueryBuilder('board')
             .leftJoin('board.invitations', 'invitation')
             .where('board.id=:boardId', { boardId })
@@ -38,5 +48,15 @@ export class CustomBoardRepository extends BaseRepository {
             .getMany();
 
         return isAuth.length !== 0;
+    }
+
+    async existListByBoardId({ boardId, listId }) {
+        const lists = await this.createQueryBuilder('board')
+            .innerJoin('board.lists', 'list')
+            .where('board.id=:boardId', { boardId })
+            .andWhere('list.id=:listId', { listId })
+            .getMany();
+
+        return lists.length !== 0;
     }
 }

--- a/server/src/dao/CustomListRepository.js
+++ b/server/src/dao/CustomListRepository.js
@@ -1,0 +1,16 @@
+import { EntityRepository } from 'typeorm';
+import { BaseRepository } from 'typeorm-transactional-cls-hooked';
+import { List } from '../model/List';
+
+@EntityRepository(List)
+export class CustomListRepository extends BaseRepository {
+    async isListOfBoard({ boardId, listId }) {
+        const lists = await this.createQueryBuilder('list')
+            .innerJoin('list.board', 'board')
+            .where('board.id=:boardId', { boardId })
+            .andWhere('list.id=:listId', { listId })
+            .getMany();
+
+        return lists.length !== 0;
+    }
+}

--- a/server/src/dao/CustomListRepository.js
+++ b/server/src/dao/CustomListRepository.js
@@ -3,14 +3,4 @@ import { BaseRepository } from 'typeorm-transactional-cls-hooked';
 import { List } from '../model/List';
 
 @EntityRepository(List)
-export class CustomListRepository extends BaseRepository {
-    async isListOfBoard({ boardId, listId }) {
-        const lists = await this.createQueryBuilder('list')
-            .innerJoin('list.board', 'board')
-            .where('board.id=:boardId', { boardId })
-            .andWhere('list.id=:listId', { listId })
-            .getMany();
-
-        return lists.length !== 0;
-    }
-}
+export class CustomListRepository extends BaseRepository {}

--- a/server/src/dto/CardDto.js
+++ b/server/src/dto/CardDto.js
@@ -1,18 +1,36 @@
-import { IsDateString, IsNumber, IsString } from 'class-validator';
+import { IsISO8601, IsNotEmpty, IsNumber, IsString, ValidateIf } from 'class-validator';
 
 export class CardDto {
-    @IsNumber()
     id;
 
-    @IsString()
     title;
 
+    content;
+
+    position;
+
+    dueDate;
+
+    listId;
+
+    @ValidateIf((o) => o.title !== undefined)
+    @IsString()
+    @IsNotEmpty()
+    title;
+
+    @ValidateIf((o) => o.content !== undefined)
     @IsString()
     content;
 
+    @ValidateIf((o) => o.position !== undefined)
     @IsNumber()
     position;
 
-    @IsDateString()
+    @ValidateIf((o) => o.dueDate !== undefined)
+    @IsISO8601()
     dueDate;
+
+    @ValidateIf((o) => o.listId !== undefined)
+    @IsNumber()
+    listId;
 }

--- a/server/src/router/CardRouter.js
+++ b/server/src/router/CardRouter.js
@@ -4,6 +4,7 @@ import { queryParser } from '../common/util/queryParser';
 import { validator } from '../common/util/validator';
 import { CardCountDto } from '../dto/CardCountDto';
 import { GetCardsByDateQueryDto } from '../dto/GetCardsByDateQueryDto';
+import { CardDto } from '../dto/CardDto';
 
 export const CardRouter = () => {
     const router = Router();
@@ -45,6 +46,23 @@ export const CardRouter = () => {
         }
 
         res.status(200).json({ cards });
+    });
+
+    router.patch('/:cardId', async (req, res) => {
+        const cardService = CardService.getInstance();
+        const { cardId } = req.params;
+        const { listId, title, content, position, dueDate } = req.body;
+        await validator(CardDto, { listId, title, content, position, dueDate });
+
+        await cardService.modifyCardById({
+            cardId,
+            listId,
+            title,
+            content,
+            position,
+            dueDate,
+        });
+        res.status(204).end();
     });
 
     return router;

--- a/server/src/router/CardRouter.js
+++ b/server/src/router/CardRouter.js
@@ -50,11 +50,13 @@ export const CardRouter = () => {
 
     router.patch('/:cardId', async (req, res) => {
         const cardService = CardService.getInstance();
+        const { id: userId } = req.user;
         const { cardId } = req.params;
         const { listId, title, content, position, dueDate } = req.body;
         await validator(CardDto, { listId, title, content, position, dueDate });
 
         await cardService.modifyCardById({
+            userId,
             cardId,
             listId,
             title,

--- a/server/src/service/BaseService.js
+++ b/server/src/service/BaseService.js
@@ -1,6 +1,7 @@
 import { getCustomRepository, getRepository } from 'typeorm';
 import { CustomBoardRepository } from '../dao/CustomBoardRepository';
 import { CustomCardRepository } from '../dao/CustomCardRepository';
+import { CustomListRepository } from '../dao/CustomListRepository';
 import { CustomUserRepository } from '../dao/CustomUserRepository';
 import { Activity } from '../model/Activity';
 import { Board } from '../model/Board';
@@ -22,5 +23,6 @@ export class BaseService {
         this.customBoardRepository = getCustomRepository(CustomBoardRepository);
         this.customCardRepository = getCustomRepository(CustomCardRepository);
         this.customUserRepository = getCustomRepository(CustomUserRepository);
+        this.customListRepository = getCustomRepository(CustomListRepository);
     }
 }

--- a/server/src/service/CardService.js
+++ b/server/src/service/CardService.js
@@ -111,14 +111,15 @@ export class CardService extends BaseService {
 
         if (!card) throw new EntityNotFoundError('card is not exist');
 
-        const { list } = await this.cardRepository.findOne(cardId, { relations: ['list'] });
-        const { board } = await this.listRepository.findOne(list.id, { relations: ['board'] });
-        const { id: boardId } = board;
-        const isAccess = await this.customBoardRepository.checkAccess({ boardId, userId });
+        const { id: boardId } = await this.customBoardRepository.findBoardByCardId(cardId);
+        const isExistUser = await this.customBoardRepository.existUserByBoardId({
+            boardId,
+            userId,
+        });
 
-        if (!isAccess) throw new ForbiddenError('no access to this card');
+        if (!isExistUser) throw new ForbiddenError('no access to this card');
 
-        if (listId && !(await this.customListRepository.isListOfBoard({ boardId, listId }))) {
+        if (listId && !(await this.customBoardRepository.existListByBoardId({ boardId, listId }))) {
             throw new ConflictError(`can't move this card to list`);
         }
 

--- a/server/src/service/CardService.js
+++ b/server/src/service/CardService.js
@@ -1,5 +1,6 @@
 import moment from 'moment-timezone';
 import { Transactional } from 'typeorm-transactional-cls-hooked';
+import { EntityNotFoundError } from '../../dist/common/error/EntityNotFoundError';
 import { BaseService } from './BaseService';
 
 export class CardService extends BaseService {
@@ -100,5 +101,20 @@ export class CardService extends BaseService {
             dueDate: moment(card.dueDate).tz('Asia/Seoul').format(),
             commentCount: card.commentCount,
         }));
+    }
+
+    @Transactional()
+    async modifyCardById({ cardId, listId, title, content, position, dueDate }) {
+        const card = await this.cardRepository.findOne(cardId);
+
+        if (!card) throw new EntityNotFoundError('card is not exist');
+
+        card.list = listId;
+        card.title = title;
+        card.content = content;
+        card.position = position;
+        card.dueDate = dueDate;
+
+        await this.cardRepository.save(card);
     }
 }

--- a/server/src/service/CardService.js
+++ b/server/src/service/CardService.js
@@ -1,6 +1,6 @@
 import moment from 'moment-timezone';
 import { Transactional } from 'typeorm-transactional-cls-hooked';
-import { BadRequestError } from '../common/error/BadRequestError';
+import { ConflictError } from '../common/error/ConflictError';
 import { EntityNotFoundError } from '../common/error/EntityNotFoundError';
 import { ForbiddenError } from '../common/error/ForbiddenError';
 import { BaseService } from './BaseService';
@@ -119,7 +119,7 @@ export class CardService extends BaseService {
         if (!isAccess) throw new ForbiddenError('no access to this card');
 
         if (listId && !(await this.customListRepository.isListOfBoard({ boardId, listId }))) {
-            throw new BadRequestError(`can't not move this card to list`);
+            throw new ConflictError(`can't move this card to list`);
         }
 
         card.list = listId;

--- a/server/test/router/CardRouter.test.js
+++ b/server/test/router/CardRouter.test.js
@@ -814,4 +814,120 @@ describe('Board API Test', () => {
             );
         });
     });
+
+    test('PATCH /api/card/{cardId} 호출할 때, 카드가 존재하지 않으면 404 반환', async () => {
+        await TestTransactionDelegate.transaction(async () => {
+            // given
+            const em = getEntityManagerOrTransactionManager('default');
+
+            const user1 = em.create(User, {
+                socialId: '1',
+                name: 'user1',
+                profileImageUrl: 'image1',
+            });
+            await em.save(user1);
+
+            const board1 = em.create(Board, {
+                title: 'board title 1',
+                color: '#FF0000',
+                creator: user1,
+            });
+            await em.save(board1);
+
+            const list1 = em.create(List, {
+                title: 'list title 1',
+                position: 1,
+                board: board1,
+                creator: user1,
+            });
+            await em.save(list1);
+
+            const card1 = em.create(Card, {
+                title: 'card title 1',
+                content: 'card content 1',
+                position: 1,
+                dueDate: moment('2020-12-03T13:40:00').format(),
+                list: list1,
+                creator: user1,
+            });
+            await em.save(card1);
+
+            const token = await jwtUtil.generateAccessToken({ userId: user1.id });
+            const cardId = 0;
+            const updateData = {
+                listId: undefined,
+                title: 'card update title',
+                content: 'card update content',
+                position: 2,
+                dueDate: moment('2020-12-30T13:40:00').format(),
+            };
+
+            // when
+            const response = await agent(app.httpServer)
+                .patch(`/api/card/${cardId}`)
+                .set('Authorization', token)
+                .send(updateData);
+
+            // then
+            expect(response.status).toEqual(404);
+        });
+    });
+
+    test('PATCH /api/card/{cardId} 호출이 성공하면 204 반환', async () => {
+        await TestTransactionDelegate.transaction(async () => {
+            // given
+            const em = getEntityManagerOrTransactionManager('default');
+
+            const user1 = em.create(User, {
+                socialId: '1',
+                name: 'user1',
+                profileImageUrl: 'image1',
+            });
+            await em.save(user1);
+
+            const board1 = em.create(Board, {
+                title: 'board title 1',
+                color: '#FF0000',
+                creator: user1,
+            });
+            await em.save(board1);
+
+            const list1 = em.create(List, {
+                title: 'list title 1',
+                position: 1,
+                board: board1,
+                creator: user1,
+            });
+            await em.save(list1);
+
+            const card1 = em.create(Card, {
+                title: 'card title 1',
+                content: 'card content 1',
+                position: 1,
+                dueDate: moment('2020-12-03T13:40:00').format(),
+                list: list1,
+                creator: user1,
+            });
+            await em.save(card1);
+
+            const token = await jwtUtil.generateAccessToken({ userId: user1.id });
+            const cardId = card1.id;
+            const updateData = {
+                listId: undefined,
+                title: 'card update title',
+                content: 'card update content',
+                position: 2,
+                dueDate: moment('2020-12-30T13:40:00').format(),
+            };
+
+            // when
+            const response = await agent(app.httpServer)
+                .patch(`/api/card/${cardId}`)
+                .set('Authorization', token)
+                .send(updateData);
+
+            // then
+            expect(response.status).toEqual(204);
+        });
+    });
 });

--- a/server/test/router/CardRouter.test.js
+++ b/server/test/router/CardRouter.test.js
@@ -815,6 +815,138 @@ describe('Board API Test', () => {
         });
     });
 
+    test('PATCH /api/card/{cardId} 호출할 때, 보드에 속한 리스트가 아닌 리스트로 옮기려하면 400 반환', async () => {
+        await TestTransactionDelegate.transaction(async () => {
+            // given
+            const em = getEntityManagerOrTransactionManager('default');
+
+            const user1 = em.create(User, {
+                socialId: '1',
+                name: 'user1',
+                profileImageUrl: 'image1',
+            });
+            await em.save(user1);
+
+            const board1 = em.create(Board, {
+                title: 'board title 1',
+                color: '#FF0000',
+                creator: user1,
+            });
+            const board2 = em.create(Board, {
+                title: 'board title 2',
+                color: '#FF0000',
+                creator: user1,
+            });
+            await em.save([board1, board2]);
+
+            const list1 = em.create(List, {
+                title: 'list title 1',
+                position: 1,
+                board: board1,
+                creator: user1,
+            });
+            const list2 = em.create(List, {
+                title: 'list title 2',
+                position: 1,
+                board: board2,
+                creator: user1,
+            });
+            await em.save([list1, list2]);
+
+            const card1 = em.create(Card, {
+                title: 'card title 1',
+                content: 'card content 1',
+                position: 1,
+                dueDate: moment('2020-12-03T13:40:00').format(),
+                list: list1,
+                creator: user1,
+            });
+            await em.save(card1);
+
+            const token = await jwtUtil.generateAccessToken({ userId: user1.id });
+            const cardId = card1.id;
+            const updateData = {
+                listId: list2.id,
+                title: 'card update title',
+                content: 'card update content',
+                position: 2,
+                dueDate: moment('2020-12-30T13:40:00').format(),
+            };
+
+            // when
+            const response = await agent(app.httpServer)
+                .patch(`/api/card/${cardId}`)
+                .set('Authorization', token)
+                .send(updateData);
+
+            // then
+            expect(response.status).toEqual(400);
+        });
+    });
+
+    test('PATCH /api/card/{cardId} 호출할 때, 카드 수정 권한이 없으면 403 반환', async () => {
+        await TestTransactionDelegate.transaction(async () => {
+            // given
+            const em = getEntityManagerOrTransactionManager('default');
+
+            const user1 = em.create(User, {
+                socialId: '1',
+                name: 'user1',
+                profileImageUrl: 'image1',
+            });
+            const user2 = em.create(User, {
+                socialId: '2',
+                name: 'user2',
+                profileImageUrl: 'image2',
+            });
+            await em.save([user1, user2]);
+
+            const board1 = em.create(Board, {
+                title: 'board title 1',
+                color: '#FF0000',
+                creator: user1,
+            });
+            await em.save(board1);
+
+            const list1 = em.create(List, {
+                title: 'list title 1',
+                position: 1,
+                board: board1,
+                creator: user1,
+            });
+            await em.save(list1);
+
+            const card1 = em.create(Card, {
+                title: 'card title 1',
+                content: 'card content 1',
+                position: 1,
+                dueDate: moment('2020-12-03T13:40:00').format(),
+                list: list1,
+                creator: user1,
+            });
+            await em.save(card1);
+
+            const token = await jwtUtil.generateAccessToken({ userId: user2.id });
+            const cardId = card1.id;
+            const updateData = {
+                listId: undefined,
+                title: 'card update title',
+                content: 'card update content',
+                position: 2,
+                dueDate: moment('2020-12-30T13:40:00').format(),
+            };
+
+            // when
+            const response = await agent(app.httpServer)
+                .patch(`/api/card/${cardId}`)
+                .set('Authorization', token)
+                .send(updateData);
+
+            // then
+            expect(response.status).toEqual(403);
+        });
+    });
+
     test('PATCH /api/card/{cardId} 호출할 때, 카드가 존재하지 않으면 404 반환', async () => {
         await TestTransactionDelegate.transaction(async () => {
             // given

--- a/server/test/router/CardRouter.test.js
+++ b/server/test/router/CardRouter.test.js
@@ -815,7 +815,7 @@ describe('Board API Test', () => {
         });
     });
 
-    test('PATCH /api/card/{cardId} 호출할 때, 보드에 속한 리스트가 아닌 리스트로 옮기려하면 400 반환', async () => {
+    test('PATCH /api/card/{cardId} 호출할 때, 보드에 속한 리스트가 아닌 리스트로 옮기려하면 409 반환', async () => {
         await TestTransactionDelegate.transaction(async () => {
             // given
             const em = getEntityManagerOrTransactionManager('default');
@@ -880,7 +880,7 @@ describe('Board API Test', () => {
                 .send(updateData);
 
             // then
-            expect(response.status).toEqual(400);
+            expect(response.status).toEqual(409);
         });
     });
 

--- a/server/test/router/CardRouter.test.js
+++ b/server/test/router/CardRouter.test.js
@@ -947,6 +947,76 @@ describe('Board API Test', () => {
         });
     });
 
+    test('PATCH /api/card/{cardId} 호출할 때, 초대 되지 않은 보드의 카드를 수정하려면 403 반환', async () => {
+        await TestTransactionDelegate.transaction(async () => {
+            // given
+            const em = getEntityManagerOrTransactionManager('default');
+
+            const user1 = em.create(User, {
+                socialId: '1',
+                name: 'user1',
+                profileImageUrl: 'image1',
+            });
+            const user2 = em.create(User, {
+                socialId: '2',
+                name: 'user2',
+                profileImageUrl: 'image2',
+            });
+            await em.save([user1, user2]);
+
+            const board1 = em.create(Board, {
+                title: 'board title 1',
+                color: '#FF0000',
+                creator: user1,
+            });
+            const board2 = em.create(Board, {
+                title: 'board title 1',
+                color: '#FF0000',
+                creator: user1,
+            });
+            await em.save([board1, board2]);
+
+            em.save(Invitation, { user: user2, board: board2 });
+
+            const list1 = em.create(List, {
+                title: 'list title 1',
+                position: 1,
+                board: board1,
+                creator: user1,
+            });
+            await em.save(list1);
+
+            const card1 = em.create(Card, {
+                title: 'card title 1',
+                content: 'card content 1',
+                position: 1,
+                dueDate: moment('2020-12-03T13:40:00').format(),
+                list: list1,
+                creator: user1,
+            });
+            await em.save(card1);
+
+            const token = await jwtUtil.generateAccessToken({ userId: user2.id });
+            const cardId = card1.id;
+            const updateData = {
+                listId: undefined,
+                title: 'card update title',
+                content: 'card update content',
+                position: 2,
+                dueDate: moment('2020-12-30T13:40:00').format(),
+            };
+
+            // when
+            const response = await agent(app.httpServer)
+                .patch(`/api/card/${cardId}`)
+                .set('Authorization', token)
+                .send(updateData);
+
+            // then
+            expect(response.status).toEqual(403);
+        });
+    });
+
     test('PATCH /api/card/{cardId} 호출할 때, 카드가 존재하지 않으면 404 반환', async () => {
         await TestTransactionDelegate.transaction(async () => {
             // given

--- a/server/test/service/CardService.test.js
+++ b/server/test/service/CardService.test.js
@@ -704,7 +704,7 @@ describe('Card Service Test', () => {
             expect(updatedCard.content).toEqual(card1.content);
             expect(updatedCard.position).toEqual(card1.position);
             expect(moment(updatedCard.dueDate).tz('Asia/Seoul').format()).toEqual(
-                updateData.dueDate,
+                moment(updateData.dueDate).tz('Asia/Seoul').format(),
             );
         });
     });
@@ -780,7 +780,7 @@ describe('Card Service Test', () => {
             expect(updatedCard.content).toEqual(updateData.content);
             expect(updatedCard.position).toEqual(updateData.position);
             expect(moment(updatedCard.dueDate).tz('Asia/Seoul').format()).toEqual(
-                updateData.dueDate,
+                moment(updateData.dueDate).tz('Asia/Seoul').format(),
             );
         });
     });

--- a/server/test/service/CardService.test.js
+++ b/server/test/service/CardService.test.js
@@ -638,4 +638,148 @@ describe('Card Service Test', () => {
             expect(cards[1]).toEqual(expect.objectContaining({ id: card1.id }));
         });
     });
+
+    test('modifyCardById(): 일부 데이터만 변경', async () => {
+        const cardService = CardService.getInstance();
+        await TestTransactionDelegate.transaction(async () => {
+            // given
+            const em = getEntityManagerOrTransactionManager('default');
+
+            const user1 = em.create(User, {
+                socialId: '1',
+                name: 'user1',
+                profileImageUrl: 'image1',
+            });
+            await em.save(user1);
+
+            const board1 = em.create(Board, {
+                title: 'board title 1',
+                color: '#FF0000',
+                creator: user1,
+            });
+            await em.save(board1);
+
+            const list1 = em.create(List, {
+                title: 'list title 1',
+                position: 1,
+                board: board1,
+                creator: user1,
+            });
+            await em.save(list1);
+
+            const card1 = em.create(Card, {
+                title: 'card title 1',
+                content: 'card content 1',
+                position: 1,
+                dueDate: moment('2020-12-03T13:40:00').format(),
+                list: list1.id,
+                creator: user1.id,
+            });
+            await em.save(card1);
+
+            const updateData = {
+                listId: undefined,
+                title: 'card update title',
+                content: undefined,
+                position: undefined,
+                dueDate: moment('2020-12-30T13:40:00').format(),
+            };
+
+            // when
+            await cardService.modifyCardById({
+                cardId: card1.id,
+                listId: updateData.listId,
+                title: updateData.title,
+                content: updateData.content,
+                position: updateData.position,
+                dueDate: updateData.dueDate,
+            });
+
+            const updatedCard = await em.findOne(Card, card1.id, { relations: ['list'] });
+
+            // then
+            expect(updatedCard.list.id).toEqual(card1.list);
+            expect(updatedCard.title).toEqual(updateData.title);
+            expect(updatedCard.content).toEqual(card1.content);
+            expect(updatedCard.position).toEqual(card1.position);
+            expect(moment(updatedCard.dueDate).tz('Asia/Seoul').format()).toEqual(
+                updateData.dueDate,
+            );
+        });
+    });
+
+    test('modifyCardById(): 전체 데이터 변경', async () => {
+        const cardService = CardService.getInstance();
+        await TestTransactionDelegate.transaction(async () => {
+            // given
+            const em = getEntityManagerOrTransactionManager('default');
+
+            const user1 = em.create(User, {
+                socialId: '1',
+                name: 'user1',
+                profileImageUrl: 'image1',
+            });
+            await em.save(user1);
+
+            const board1 = em.create(Board, {
+                title: 'board title 1',
+                color: '#FF0000',
+                creator: user1,
+            });
+            await em.save(board1);
+
+            const list1 = em.create(List, {
+                title: 'list title 1',
+                position: 1,
+                board: board1,
+                creator: user1,
+            });
+            const list2 = em.create(List, {
+                title: 'list title 2',
+                position: 1,
+                board: board1,
+                creator: user1,
+            });
+            await em.save([list1, list2]);
+
+            const card1 = em.create(Card, {
+                title: 'card title 1',
+                content: 'card content 1',
+                position: 1,
+                dueDate: moment('2020-12-03T13:40:00').format(),
+                list: list1,
+                creator: user1,
+            });
+            await em.save(card1);
+
+            const updateData = {
+                listId: list2.id,
+                title: 'card update title',
+                content: 'card update content',
+                position: 2,
+                dueDate: moment('2020-12-30T13:40:00').format(),
+            };
+
+            // when
+            await cardService.modifyCardById({
+                cardId: card1.id,
+                listId: updateData.listId,
+                title: updateData.title,
+                content: updateData.content,
+                position: updateData.position,
+                dueDate: updateData.dueDate,
+            });
+
+            const updatedCard = await em.findOne(Card, card1.id, { relations: ['list'] });
+
+            // then
+            expect(updatedCard.list.id).toEqual(updateData.listId);
+            expect(updatedCard.title).toEqual(updateData.title);
+            expect(updatedCard.content).toEqual(updateData.content);
+            expect(updatedCard.position).toEqual(updateData.position);
+            expect(moment(updatedCard.dueDate).tz('Asia/Seoul').format()).toEqual(
+                updateData.dueDate,
+            );
+        });
+    });
 });

--- a/server/test/service/CardService.test.js
+++ b/server/test/service/CardService.test.js
@@ -687,6 +687,7 @@ describe('Card Service Test', () => {
 
             // when
             await cardService.modifyCardById({
+                userId: user1.id,
                 cardId: card1.id,
                 listId: updateData.listId,
                 title: updateData.title,
@@ -762,6 +763,7 @@ describe('Card Service Test', () => {
 
             // when
             await cardService.modifyCardById({
+                userId: user1.id,
                 cardId: card1.id,
                 listId: updateData.listId,
                 title: updateData.title,


### PR DESCRIPTION
# 카드 수정 API 구현

## 📎 해당 이슈

이슈 링크 (#199)

## 🛠 구현 내용 

- 카드 수정 API 구현
- 요청 성공 시, 200 응답
- 현재 보드에 속한 리스트가 아닌 리스트로 이동힐 경우, 409 응답
- 카드 수정 권한이 없을 경우, 403 응답
- 수정할 카드를 찾을 수 없는 경우, 404 응답

## 🙋‍ 리뷰어 참고 사항 

현재 보드에 속한 리스트가 아닌 리스트로 이동힐 경우 어떤 응답이 좋을지 고민하다가..🤔
request body의 list id의 값이 잘못된 경우고 요청 수정 없이 동일한 요청을 보내지 말라는 의미를 가진 것이 400 응답이라 생각하여 400 응답으로 했었습니다.
그러나 좀 더 고민해보니 카드가 속하는 리스트가 보드에 속하지 않는 것은 서버가 가진 데이터의 상태와 충돌하는 것으로 볼 수도 있을 것 같아 409 응답이 적절할 것이라고 생각하여 409 응답으로 수정했습니다.
다른 분들은 어떤 응답이 적절할 것 같다고 생각하시나요? 다른 분들 의견이 궁금합니다.👀