### PR TITLE
보드 전체 조회 API 명세서 불일치 문제 수정

### DIFF
--- a/server/src/service/BoardService.js
+++ b/server/src/service/BoardService.js
@@ -14,28 +14,12 @@ export class BoardService extends BaseService {
         return BoardService.instance;
     }
 
-    async getMyBoards(id) {
-        const boards = await this.boardRepository.find({
-            select: ['id', 'title', 'color'],
-            where: { creator: id },
-        });
-        return boards;
-    }
-
-    async getInvitedBoards(id) {
-        const boards = await this.boardRepository
-            .createQueryBuilder('board')
-            .select(['board.id', 'board.title', 'board.color'])
-            .innerJoin('board.invitations', 'invitation', 'invitation.user_id=:userId', {
-                userId: id,
-            })
-            .getMany();
-        return boards;
-    }
-
     @Transactional()
     async getBoardsByUserId(userId) {
-        const promises = [this.getMyBoards(userId), this.getInvitedBoards(userId)];
+        const promises = [
+            this.customBoardRepository.findByCreatorId(userId),
+            this.customBoardRepository.findInvitedBoardsByUserId(userId),
+        ];
         const [myBoards, invitedBoards] = await Promise.all(promises);
 
         return { myBoards, invitedBoards };

--- a/server/src/service/BoardService.js
+++ b/server/src/service/BoardService.js
@@ -16,7 +16,7 @@ export class BoardService extends BaseService {
 
     async getMyBoards(id) {
         const boards = await this.boardRepository.find({
-            select: ['id', 'title'],
+            select: ['id', 'title', 'color'],
             where: { creator: id },
         });
         return boards;
@@ -25,8 +25,7 @@ export class BoardService extends BaseService {
     async getInvitedBoards(id) {
         const boards = await this.boardRepository
             .createQueryBuilder('board')
-            .select('board.id')
-            .addSelect('board.title')
+            .select(['board.id', 'board.title', 'board.color'])
             .innerJoin('board.invitations', 'invitation', 'invitation.user_id=:userId', {
                 userId: id,
             })


### PR DESCRIPTION
# 보드 전체 조회 API 명세서 불일치 문제 수정

## 📎 해당 이슈

이슈 링크 (#220)

## 🛠 구현 내용 

- 보드 전체 조회시, 응답 값에 보드 color 값 추가
- 동일한 기능의 함수 제거

## 🙋‍ 리뷰어 참고 사항 

