### PR TITLE
댓글 추가 API 연동 및 일부 기능 수정

### DIFF
--- a/iOS/AreUDone/AreUDone/CardDetailScene/CardDetailCoordinator.swift
+++ b/iOS/AreUDone/AreUDone/CardDetailScene/CardDetailCoordinator.swift
@@ -92,7 +92,7 @@ extension CardDetailCoordinator {
     navigationController?.present(calendarPickerViewController, animated: true)
   }
   
-  func showMemberUpdate(with cardId: Int, boardId: Int, cardMember: [User]?) {
+  func showMemberUpdate(with cardId: Int, boardId: Int, cardMember: [User]?, delegate: MemberUpdateViewControllerDelegate) {
     memberUpdateCoordinator = MemberUpdateCoordinator(
       router: router,
       cardId: cardId,
@@ -104,6 +104,7 @@ extension CardDetailCoordinator {
     guard let memberUpdateViewController = memberUpdateCoordinator.start()
             as? MemberUpdateViewController
     else { return }
+    memberUpdateViewController.delegate = delegate
     
     let subNavigationViewController = UINavigationController()
     

--- a/iOS/AreUDone/AreUDone/CardDetailScene/View/Controller/CardDetailViewController.swift
+++ b/iOS/AreUDone/AreUDone/CardDetailScene/View/Controller/CardDetailViewController.swift
@@ -338,7 +338,9 @@ private extension CardDetailViewController {
 extension CardDetailViewController: CommentViewDelegate {
   
   func commentSaveButtonTapped(with comment: String) {
-    viewModel.addComment(with: comment)
+    viewModel.addComment(with: comment) { [weak self] in
+      self?.viewModel.fetchDetailCard()
+    }
   }
 }
 

--- a/iOS/AreUDone/AreUDone/CardDetailScene/View/Controller/CardDetailViewController.swift
+++ b/iOS/AreUDone/AreUDone/CardDetailScene/View/Controller/CardDetailViewController.swift
@@ -100,7 +100,7 @@ private extension CardDetailViewController {
       
       cell.update(with: comment)
       
-      self?.viewModel.prepareUpdateCell  { userId in
+      self?.viewModel.prepareUpdateCell { userId in
         guard comment.user.id == userId else { return }
         cell.confirmEditOption()
         cell.delegate = self
@@ -418,7 +418,7 @@ extension CardDetailViewController: CardDetailMemberViewDelegate {
   
   func cardDetailMemberEditButtonTapped() {
     viewModel.prepareUpdateMember { (cardId, boardId, cardMembers) in
-      cardDetailCoordinator?.showMemberUpdate(with: cardId, boardId: boardId, cardMember: cardMembers)
+      cardDetailCoordinator?.showMemberUpdate(with: cardId, boardId: boardId, cardMember: cardMembers, delegate: self)
     }
   }
 }
@@ -452,3 +452,10 @@ extension CardDetailViewController: CommentCollectionViewCellDelegate {
   }
 }
 
+
+extension CardDetailViewController: MemberUpdateViewControllerDelegate {
+  
+  func memberUpdateViewControllerWillDisappear() {
+    viewModel.fetchDetailCard()
+  }
+}

--- a/iOS/AreUDone/AreUDone/CardDetailScene/View/Controller/CardDetailViewController.swift
+++ b/iOS/AreUDone/AreUDone/CardDetailScene/View/Controller/CardDetailViewController.swift
@@ -389,9 +389,10 @@ extension CardDetailViewController: CardDetailDueDateViewDelegate {
 extension CardDetailViewController: CalendarPickerViewControllerDelegate {
   
   func send(selectedDate: String) {
-    viewModel.updateDueDate(with: selectedDate)
-    DispatchQueue.main.async { [weak self] in
-      self?.stackView.updateDueDateView(with: selectedDate)
+    viewModel.updateDueDate(with: selectedDate) {
+      DispatchQueue.main.async { [weak self] in
+        self?.stackView.updateDueDateView(with: selectedDate)
+      }
     }
   }
 }
@@ -402,9 +403,10 @@ extension CardDetailViewController: CalendarPickerViewControllerDelegate {
 extension CardDetailViewController: ContentInputViewControllerDelegate {
   
   func send(with content: String) {
-    viewModel.updateContent(with: content)
-    DispatchQueue.main.async { [weak self] in
-      self?.stackView.updateContentView(with: content)
+    viewModel.updateContent(with: content) {
+      DispatchQueue.main.async { [weak self] in
+        self?.stackView.updateContentView(with: content)
+      }
     }
   }
 }

--- a/iOS/AreUDone/AreUDone/CardDetailScene/View/Controller/CardDetailViewController.swift
+++ b/iOS/AreUDone/AreUDone/CardDetailScene/View/Controller/CardDetailViewController.swift
@@ -239,6 +239,9 @@ private extension CardDetailViewController {
     bindingCardDetailBoardTitle()
     bindingCardDetailMemberView()
     bindingCommentViewProfileImage()
+    bindingUpdateDueDateView()
+    bindingUpdateContentView()
+    bindingPrepareForUpdateMemberView()
   }
   
   func bindingCardDetailContentView() {
@@ -304,6 +307,29 @@ private extension CardDetailViewController {
       DispatchQueue.main.async {
         self?.cardDetailMemberView.update(with: members)
       }
+    }
+  }
+  
+  func bindingUpdateDueDateView() {
+    viewModel.bindingUpdateDueDateView { [weak self] selectedDate in
+      DispatchQueue.main.async { [weak self] in
+        self?.stackView.updateDueDateView(with: selectedDate)
+      }
+    }
+  }
+  
+  func bindingUpdateContentView() {
+    viewModel.bindingUpdateContentView { [weak self] content in
+      DispatchQueue.main.async { [weak self] in
+        self?.stackView.updateContentView(with: content)
+      }
+    }
+  }
+  
+  func bindingPrepareForUpdateMemberView() {
+    viewModel.bindingPrepareForUpdateMemberView { [weak self] (cardId, boardId, cardMembers) in
+      guard let self = self else { return }
+      self.cardDetailCoordinator?.showMemberUpdate(with: cardId, boardId: boardId, cardMember: cardMembers, delegate: self)
     }
   }
 }
@@ -389,11 +415,7 @@ extension CardDetailViewController: CardDetailDueDateViewDelegate {
 extension CardDetailViewController: CalendarPickerViewControllerDelegate {
   
   func send(selectedDate: String) {
-    viewModel.updateDueDate(with: selectedDate) {
-      DispatchQueue.main.async { [weak self] in
-        self?.stackView.updateDueDateView(with: selectedDate)
-      }
-    }
+    viewModel.updateDueDate(with: selectedDate)
   }
 }
 
@@ -403,11 +425,7 @@ extension CardDetailViewController: CalendarPickerViewControllerDelegate {
 extension CardDetailViewController: ContentInputViewControllerDelegate {
   
   func send(with content: String) {
-    viewModel.updateContent(with: content) {
-      DispatchQueue.main.async { [weak self] in
-        self?.stackView.updateContentView(with: content)
-      }
-    }
+    viewModel.updateContent(with: content)
   }
 }
 
@@ -417,9 +435,7 @@ extension CardDetailViewController: ContentInputViewControllerDelegate {
 extension CardDetailViewController: CardDetailMemberViewDelegate {
   
   func cardDetailMemberEditButtonTapped() {
-    viewModel.prepareUpdateMember { (cardId, boardId, cardMembers) in
-      cardDetailCoordinator?.showMemberUpdate(with: cardId, boardId: boardId, cardMember: cardMembers, delegate: self)
-    }
+    viewModel.prepareUpdateMemberView()
   }
 }
 
@@ -452,6 +468,8 @@ extension CardDetailViewController: CommentCollectionViewCellDelegate {
   }
 }
 
+
+// MARK:- Extension MemberUpdateViewControllerDelegate
 
 extension CardDetailViewController: MemberUpdateViewControllerDelegate {
   

--- a/iOS/AreUDone/AreUDone/CardDetailScene/ViewModel/CardDetailViewModel.swift
+++ b/iOS/AreUDone/AreUDone/CardDetailScene/ViewModel/CardDetailViewModel.swift
@@ -19,8 +19,8 @@ protocol CardDetailViewModelProtocol {
   
   func fetchDetailCard()
   func addComment(with comment: String, completionHandler: @escaping (() -> Void))
-  func updateDueDate(with dueDate: String)
-  func updateContent(with content: String)
+  func updateDueDate(with dueDate: String, completionHandler: @escaping (() -> Void))
+  func updateContent(with content: String, completionHandler: @escaping (() -> Void))
   func prepareUpdateMember(handler: (Int, Int, [User]?) -> Void)
   func prepareUpdateCell(handler: (Int) -> Void)
   func deleteComment(with commentId: Int, completionHandler: @escaping () -> Void)
@@ -106,14 +106,11 @@ final class CardDetailViewModel: CardDetailViewModelProtocol {
     }
   }
   
-  func updateDueDate(with dueDate: String) {
-    cardService.updateCard(
-      id: id,
-      dueDate: dueDate
-    ) { result in
+  func updateDueDate(with dueDate: String, completionHandler: @escaping (() -> Void)) {
+    cardService.updateCard(id: id, dueDate: dueDate) { result in
       switch result {
       case .success(()):
-        break
+        completionHandler()
         
       case .failure(let error):
         print(error)
@@ -121,14 +118,11 @@ final class CardDetailViewModel: CardDetailViewModelProtocol {
     }
   }
   
-  func updateContent(with content: String) {
-    cardService.updateCard(
-      id: id,
-      content: content
-    ) { result in
+  func updateContent(with content: String, completionHandler: @escaping (() -> Void)) {
+    cardService.updateCard(id: id, content: content) { result in
       switch result {
       case .success(()):
-        break
+        completionHandler()
         
       case .failure(let error):
         print(error)

--- a/iOS/AreUDone/AreUDone/CardDetailScene/ViewModel/CardDetailViewModel.swift
+++ b/iOS/AreUDone/AreUDone/CardDetailScene/ViewModel/CardDetailViewModel.swift
@@ -16,12 +16,15 @@ protocol CardDetailViewModelProtocol {
   func bindingCardDetailBoardTitle(handler: @escaping ((String) -> Void))
   func bindingCommentViewProfileImage(handler: @escaping ((Data) -> Void))
   func bindingCardDetailMemberView(handler: @escaping (([User]?) -> Void))
+  func bindingUpdateDueDateView(handler: @escaping ((String) -> Void))
+  func bindingUpdateContentView(handler: @escaping ((String) -> Void))
+  func bindingPrepareForUpdateMemberView(handler: @escaping ((Int, Int, [User]?) -> Void))
   
   func fetchDetailCard()
   func addComment(with comment: String, completionHandler: @escaping (() -> Void))
-  func updateDueDate(with dueDate: String, completionHandler: @escaping (() -> Void))
-  func updateContent(with content: String, completionHandler: @escaping (() -> Void))
-  func prepareUpdateMember(handler: (Int, Int, [User]?) -> Void)
+  func updateDueDate(with dueDate: String)
+  func updateContent(with content: String)
+  func prepareUpdateMemberView()
   func prepareUpdateCell(handler: (Int) -> Void)
   func deleteComment(with commentId: Int, completionHandler: @escaping () -> Void)
   func fetchProfileImage(with urlAsString: String, completionHandler: @escaping ((Data) -> Void))
@@ -47,6 +50,7 @@ final class CardDetailViewModel: CardDetailViewModelProtocol {
   private var updateContentHandler: ((String) -> Void)?
   private var commentViewProfileImageHandler: ((Data) -> Void)?
   private var cardDetailMemberViewHandler: (([User]?) -> Void)?
+  private var prepareForUpdateMemberViewHandler: ((Int, Int, [User]?) -> Void)?
   
   private let cache: NSCache<NSString, NSData> = NSCache()
   
@@ -106,11 +110,11 @@ final class CardDetailViewModel: CardDetailViewModelProtocol {
     }
   }
   
-  func updateDueDate(with dueDate: String, completionHandler: @escaping (() -> Void)) {
-    cardService.updateCard(id: id, dueDate: dueDate) { result in
+  func updateDueDate(with dueDate: String) {
+    cardService.updateCard(id: id, dueDate: dueDate) { [weak self] result in
       switch result {
       case .success(()):
-        completionHandler()
+        self?.updateDueDateHandler?(dueDate)
         
       case .failure(let error):
         print(error)
@@ -118,11 +122,11 @@ final class CardDetailViewModel: CardDetailViewModelProtocol {
     }
   }
   
-  func updateContent(with content: String, completionHandler: @escaping (() -> Void)) {
-    cardService.updateCard(id: id, content: content) { result in
+  func updateContent(with content: String) {
+    cardService.updateCard(id: id, content: content) { [weak self] result in
       switch result {
       case .success(()):
-        completionHandler()
+        self?.updateContentHandler?(content)
         
       case .failure(let error):
         print(error)
@@ -153,9 +157,9 @@ final class CardDetailViewModel: CardDetailViewModelProtocol {
     handler(userId)
   }
   
-  func prepareUpdateMember(handler: (Int, Int, [User]?) -> Void) {
+  func prepareUpdateMemberView() {
     guard let boardId = boardId else { return }
-    handler(id, boardId, cardMembers)
+    prepareForUpdateMemberViewHandler?(id, boardId, cardMembers)
   }
   
   func deleteComment(with commentId: Int, completionHandler: @escaping () -> Void) {
@@ -224,5 +228,17 @@ extension CardDetailViewModel {
   
   func bindingCardDetailMemberView(handler: @escaping (([User]?) -> Void)) {
     cardDetailMemberViewHandler = handler
+  }
+  
+  func bindingUpdateDueDateView(handler: @escaping ((String) -> Void)) {
+    updateDueDateHandler = handler
+  }
+  
+  func bindingUpdateContentView(handler: @escaping ((String) -> Void)) {
+    updateContentHandler = handler
+  }
+  
+  func bindingPrepareForUpdateMemberView(handler: @escaping ((Int, Int, [User]?) -> Void)) {
+    prepareForUpdateMemberViewHandler = handler
   }
 }

--- a/iOS/AreUDone/AreUDone/CardDetailScene/ViewModel/CardDetailViewModel.swift
+++ b/iOS/AreUDone/AreUDone/CardDetailScene/ViewModel/CardDetailViewModel.swift
@@ -18,7 +18,7 @@ protocol CardDetailViewModelProtocol {
   func bindingCardDetailMemberView(handler: @escaping (([User]?) -> Void))
   
   func fetchDetailCard()
-  func addComment(with comment: String)
+  func addComment(with comment: String, completionHandler: @escaping (() -> Void))
   func updateDueDate(with dueDate: String)
   func updateContent(with content: String)
   func prepareUpdateMember(handler: (Int, Int, [User]?) -> Void)
@@ -94,8 +94,16 @@ final class CardDetailViewModel: CardDetailViewModelProtocol {
     }
   }
   
-  func addComment(with comment: String) {
-    // TODO:- CommentService
+  func addComment(with comment: String, completionHandler: @escaping (() -> Void)) {
+    commentService.createComment(with: id, content: comment) { result in
+      switch result {
+      case .success(()):
+        completionHandler()
+        
+      case .failure(let error):
+        print(error)
+      }
+    }
   }
   
   func updateDueDate(with dueDate: String) {

--- a/iOS/AreUDone/AreUDone/MemberUpdateScene/View/Controller/MemberUpdateViewController.swift
+++ b/iOS/AreUDone/AreUDone/MemberUpdateScene/View/Controller/MemberUpdateViewController.swift
@@ -7,6 +7,11 @@
 
 import UIKit
 
+protocol MemberUpdateViewControllerDelegate: NSObject {
+  
+  func memberUpdateViewControllerWillDisappear()
+}
+
 enum MemberSection: CaseIterable {
   case invited
   case notInvited
@@ -30,6 +35,7 @@ final class MemberUpdateViewController: UIViewController {
   
   private let viewModel: MemberUpdateViewModelProtocol
   weak var coordinator: MemberUpdateCoordinator?
+  weak var delegate: MemberUpdateViewControllerDelegate?
   
   private lazy var dataSource = configureDataSource()
   
@@ -64,6 +70,12 @@ final class MemberUpdateViewController: UIViewController {
     
     configure()
     applySnapshot(animatingDifferences: false)
+  }
+  
+  override func viewWillDisappear(_ animated: Bool) {
+    super.viewWillDisappear(animated)
+    
+    delegate?.memberUpdateViewControllerWillDisappear()
   }
 }
 

--- a/iOS/AreUDone/AreUDone/Service/CommentService/CommentService.swift
+++ b/iOS/AreUDone/AreUDone/Service/CommentService/CommentService.swift
@@ -10,6 +10,7 @@ import NetworkFramework
 
 protocol CommentServiceProtocol {
   
+  func createComment(with cardId: Int, content: String, completionHandler: @escaping ((Result<Void, APIError>) -> Void))
   func deleteComment(with commentId: Int, compeletionHandler: @escaping ((Result<Void, APIError>) -> Void))
 }
 
@@ -28,8 +29,11 @@ class CommentService: CommentServiceProtocol {
   
   
   // MARK: - Method
-  func createComment() {
-    
+  
+  func createComment(with cardId: Int, content: String, completionHandler: @escaping ((Result<Void, APIError>) -> Void)) {
+    router.request(route: CommentEndPoint.createComment(cardId: cardId, content: content)) { (result: Result<Void, APIError>) in
+      completionHandler(result)
+    }
   }
   
   func deleteComment(with commentId: Int, compeletionHandler: @escaping ((Result<Void, APIError>) -> Void)) {


### PR DESCRIPTION
# 댓글 추가 API 연동 및 일부 기능 수정

## 📎 해당 이슈
#223 

## 🛠 구현 내용 

- 댓글 추가 API 연동
- CardDetail의 content 업데이트 시 네트워크 통신이 성공하면 UI 변경하도록 수정
- CardDetail의 dueDate 업데이트 시 네트워크 통신이 성공하면 UI 변경하도록 수정

## 🙋‍ 리뷰어 참고 사항 
없습니다.
