### PR TITLE
카드 상세 조회 API 구현 완료

### DIFF
--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -1,0 +1,23 @@
+version: "3"
+services:
+  mysql:
+    image: mysql:5.7
+    # volumes:
+    #   - "./.mysql:/var/lib/mysql"
+    restart: always
+    ports:
+      - ${MYSQL_PORT}:3306
+    environment:
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+    command: 
+      - --default-authentication-plugin=mysql_native_password 
+      - --character-set-server=utf8 
+      - --collation-server=utf8_unicode_ci
+  adminer:
+    image: adminer
+    container_name: adminer
+    ports:
+      - 8888:8080

--- a/server/src/common/error/ErrorCode.js
+++ b/server/src/common/error/ErrorCode.js
@@ -6,6 +6,7 @@ const ErrorCode = {
     BAD_REQUEST: { code: 1004, httpStatusCode: 400, message: 'Bad Request' },
     VALIDATION_ERROR: { code: 1005, httpStatusCode: 400, message: 'Validation error occurs' },
     CONFLICT: { code: 1006, httpStatusCode: 409, message: 'conflict' },
+    INTERNAL_SERVER_ERROR: { code: 5000, httpStatusCode: 500, message: 'Internal Server Error' },
 };
 
 export { ErrorCode };

--- a/server/src/common/error/InternalServerError.js
+++ b/server/src/common/error/InternalServerError.js
@@ -1,0 +1,8 @@
+import { BusinessError } from './BusinessError';
+import { ErrorCode } from './ErrorCode';
+
+export class InternalServerError extends BusinessError {
+    constructor(message) {
+        super(ErrorCode.INTERNAL_SERVER_ERROR, message);
+    }
+}

--- a/server/src/dao/CustomCardRepository.js
+++ b/server/src/dao/CustomCardRepository.js
@@ -72,4 +72,27 @@ export class CustomCardRepository extends BaseRepository {
 
         return cardCountList;
     }
+
+    async findWithListAndBoardById(cardId) {
+        const card = await this.createQueryBuilder('a')
+            .innerJoinAndSelect('a.list', 'b')
+            .innerJoinAndSelect('b.board', 'b_0')
+            .innerJoinAndSelect('a.creator', 'c')
+            .where('a.id = :cardId', { cardId })
+            .getOne();
+
+        return card;
+    }
+
+    async findWithCommentsAndMembers(cardId) {
+        const card = await this.createQueryBuilder('a')
+            .leftJoinAndSelect('a.comments', 'b')
+            .leftJoinAndSelect('b.user', 'b_0')
+            .leftJoinAndSelect('a.members', 'c')
+            .leftJoinAndSelect('c.user', 'c_0')
+            .where('a.id = :cardId', { cardId })
+            .getOne();
+
+        return card;
+    }
 }

--- a/server/src/model/Comment.js
+++ b/server/src/model/Comment.js
@@ -1,4 +1,11 @@
-import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import {
+    Column,
+    CreateDateColumn,
+    Entity,
+    JoinColumn,
+    ManyToOne,
+    PrimaryGeneratedColumn,
+} from 'typeorm';
 import { Card } from './Card';
 import { User } from './User';
 
@@ -9,6 +16,9 @@ export class Comment {
 
     @Column({ name: 'content', type: 'varchar' })
     content;
+
+    @CreateDateColumn({ name: 'created_at', type: 'datetime' })
+    createdAt;
 
     @ManyToOne(() => User, (user) => user.comments, { nullable: false })
     @JoinColumn({ name: 'user_id' })

--- a/server/src/router/CardRouter.js
+++ b/server/src/router/CardRouter.js
@@ -5,6 +5,7 @@ import { validator } from '../common/util/validator';
 import { CardCountDto } from '../dto/CardCountDto';
 import { GetCardsByDateQueryDto } from '../dto/GetCardsByDateQueryDto';
 import { CardDto } from '../dto/CardDto';
+import { BadRequestError } from '../common/error/BadRequestError';
 
 export const CardRouter = () => {
     const router = Router();
@@ -65,6 +66,20 @@ export const CardRouter = () => {
             dueDate,
         });
         res.status(204).end();
+    });
+
+    router.get('/:cardId', async (req, res) => {
+        const cardService = CardService.getInstance();
+        const userId = req.user.id;
+        const { cardId } = req.params;
+
+        if (cardId === undefined) {
+            throw new BadRequestError('No params');
+        }
+
+        const card = await cardService.getCard({ userId, cardId });
+
+        res.status(200).json(card);
     });
 
     return router;

--- a/server/test/router/CardRouter.test.js
+++ b/server/test/router/CardRouter.test.js
@@ -1198,7 +1198,7 @@ describe('Board API Test', () => {
             title: 'card title 0',
             content: 'card content 0',
             position: 0,
-            dueDate: moment('2020-12-03T09:37:00').format(),
+            dueDate: moment.tz('2020-12-03T09:37:00', 'Asia/Seoul').format(),
             list: list0,
             creator: user0,
         });
@@ -1258,7 +1258,7 @@ describe('Board API Test', () => {
                 title: 'card title 0',
                 content: 'card content 0',
                 position: 0,
-                dueDate: moment('2020-12-03T09:37:00').format(),
+                dueDate: moment.tz('2020-12-03T09:37:00', 'Asia/Seoul').format(),
                 list: list0,
                 creator: user0,
             });

--- a/server/test/router/CardRouter.test.js
+++ b/server/test/router/CardRouter.test.js
@@ -6,6 +6,7 @@ import { Application } from '../../src/Application';
 import { JwtUtil } from '../../src/common/util/JwtUtil';
 import { Board } from '../../src/model/Board';
 import { Card } from '../../src/model/Card';
+import { Comment } from '../../src/model/Comment';
 import { Invitation } from '../../src/model/Invitation';
 import { List } from '../../src/model/List';
 import { Member } from '../../src/model/Member';
@@ -1130,6 +1131,196 @@ describe('Board API Test', () => {
 
             // then
             expect(response.status).toEqual(204);
+        });
+    });
+
+    test('GET /api/card/{cardId} user0이 존재하지 않는 카드 id로 API 호출 시 404 반환', async () => {
+        // given
+        const em = getEntityManagerOrTransactionManager('default');
+
+        const user0 = em.create(User, {
+            socialId: 0,
+            name: 'youngxpepp',
+            profileImageUrl: 'http://',
+        });
+        await em.save(user0);
+
+        const accessToken = await jwtUtil.generateAccessToken({ userId: user0.id });
+
+        // when
+        const response = await agent(app.httpServer)
+            .get(`/api/card/1`)
+            .set('Authorization', accessToken)
+            .send();
+
+        // then
+        expect(response.status).toEqual(404);
+        expect(response.body).toEqual({
+            error: {
+                code: 1000,
+                message: 'Not found card',
+            },
+        });
+    });
+
+    test('GET /api/card/{cardId} user1이 초대되지 않은 보드의 카드를 조회할 때 403 반환', async () => {
+        // given
+        const em = getEntityManagerOrTransactionManager('default');
+
+        const user0 = em.create(User, {
+            socialId: '0',
+            name: 'youngxpepp',
+            profileImageUrl: 'http://',
+        });
+        const user1 = em.create(User, {
+            socialId: '1',
+            name: 'park-sooyeon',
+            profileImageUrl: 'http://',
+        });
+        await em.save([user0, user1]);
+
+        const board0 = em.create(Board, {
+            title: 'board title 0',
+            color: '#FFFFFF',
+            creator: user0,
+        });
+        await em.save(board0);
+
+        const list0 = em.create(List, {
+            title: 'list title 0',
+            position: 0,
+            board: board0,
+            creator: user0,
+        });
+        await em.save(list0);
+
+        const card0 = em.create(Card, {
+            title: 'card title 0',
+            content: 'card content 0',
+            position: 0,
+            dueDate: moment('2020-12-03T09:37:00').format(),
+            list: list0,
+            creator: user0,
+        });
+        await em.save(card0);
+
+        const accessToken = await jwtUtil.generateAccessToken({ userId: user1.id });
+
+        // when
+        const response = await agent(app.httpServer)
+            .get(`/api/card/${card0.id}`)
+            .set('Authorization', accessToken)
+            .send();
+
+        // then
+        expect(response.status).toEqual(403);
+        expect(response.body).toEqual({
+            error: {
+                code: 1003,
+                message: `You're not invited`,
+            },
+        });
+    });
+
+    test('GET /api/card/{cardId} user0이 본인이 만든 card0을 조회하면 200 반환', async () => {
+        await TestTransactionDelegate.transaction(async () => {
+            // given
+            const em = getEntityManagerOrTransactionManager('default');
+
+            const user0 = em.create(User, {
+                socialId: '0',
+                name: 'youngxpepp',
+                profileImageUrl: 'http://',
+            });
+            const user1 = em.create(User, {
+                socialId: '1',
+                name: 'park-sooyeon',
+                profileImageUrl: 'http://',
+            });
+            await em.save([user0, user1]);
+
+            const board0 = em.create(Board, {
+                title: 'board title 0',
+                color: '#FFFFFF',
+                creator: user0,
+            });
+            await em.save(board0);
+
+            const list0 = em.create(List, {
+                title: 'list title 0',
+                position: 0,
+                board: board0,
+                creator: user0,
+            });
+            await em.save(list0);
+
+            const card0 = em.create(Card, {
+                title: 'card title 0',
+                content: 'card content 0',
+                position: 0,
+                dueDate: moment('2020-12-03T09:37:00').format(),
+                list: list0,
+                creator: user0,
+            });
+            await em.save(card0);
+
+            await em.save(em.create(Invitation, { user: user1, board: board0 }));
+            await em.save(
+                em.create(Member, {
+                    user: user1,
+                    card: card0,
+                }),
+            );
+
+            const comment0 = em.create(Comment, {
+                content: 'hey~',
+                user: user1,
+                card: card0,
+            });
+            await em.save(comment0);
+
+            const accessToken = await jwtUtil.generateAccessToken({ userId: user0.id });
+
+            // when
+            const response = await agent(app.httpServer)
+                .get(`/api/card/${card0.id}`)
+                .set('Authorization', accessToken)
+                .send();
+
+            expect(response.status).toEqual(200);
+            expect(response.body).toEqual({
+                id: card0.id,
+                title: card0.title,
+                content: card0.content,
+                dueDate: card0.dueDate,
+                list: {
+                    id: list0.id,
+                    title: list0.title,
+                },
+                board: {
+                    id: board0.id,
+                    title: board0.title,
+                },
+                members: expect.any(Array),
+                comments: expect.any(Array),
+            });
+            expect(response.body.members).toHaveLength(1);
+            expect(response.body.members?.[0]).toEqual({
+                id: user1.id,
+                name: user1.name,
+                profileImageUrl: user1.profileImageUrl,
+            });
+            expect(response.body.comments).toHaveLength(1);
+            expect(response.body.comments?.[0]).toEqual({
+                id: comment0.id,
+                content: comment0.content,
+                createdAt: moment(comment0.createdAt).tz('Asia/Seoul').format(),
+                user: {
+                    id: user1.id,
+                    name: user1.name,
+                    profileImageUrl: user1.profileImageUrl,
+                },
+            });
         });
     });
 });

--- a/server/test/service/CardService.getCard.test.js
+++ b/server/test/service/CardService.getCard.test.js
@@ -87,7 +87,7 @@ describe('CardService.getCard() Test', () => {
                 title: 'card title 0',
                 content: 'card content 0',
                 position: 0,
-                dueDate: moment('2020-12-03T09:37:00').format(),
+                dueDate: moment.tz('2020-12-03T09:37:00', 'Asia/Seoul').format(),
                 list: list0,
                 creator: user0,
             });
@@ -141,7 +141,7 @@ describe('CardService.getCard() Test', () => {
                 title: 'card title 0',
                 content: 'card content 0',
                 position: 0,
-                dueDate: moment('2020-12-03T09:37:00').format(),
+                dueDate: moment.tz('2020-12-03T09:37:00', 'Asia/Seoul').format(),
                 list: list0,
                 creator: user0,
             });

--- a/server/test/service/CardService.getCard.test.js
+++ b/server/test/service/CardService.getCard.test.js
@@ -1,0 +1,204 @@
+import moment from 'moment';
+import { getEntityManagerOrTransactionManager } from 'typeorm-transactional-cls-hooked';
+import { Application } from '../../src/Application';
+import { EntityNotFoundError } from '../../src/common/error/EntityNotFoundError';
+import { ForbiddenError } from '../../src/common/error/ForbiddenError';
+import { Board } from '../../src/model/Board';
+import { Card } from '../../src/model/Card';
+import { Comment } from '../../src/model/Comment';
+import { Invitation } from '../../src/model/Invitation';
+import { List } from '../../src/model/List';
+import { Member } from '../../src/model/Member';
+import { User } from '../../src/model/User';
+import { CardService } from '../../src/service/CardService';
+import { TestTransactionDelegate } from '../TestTransactionDelegate';
+
+describe('CardService.getCard() Test', () => {
+    const app = new Application();
+
+    beforeAll(async () => {
+        await app.initEnvironment();
+        await app.initDatabase();
+    });
+
+    afterAll(async (done) => {
+        await app.close();
+        done();
+    });
+
+    test('존재하지 않는 카드 id로 getCard 호출 시 EntityNotFoundError 발생', async () => {
+        const cardService = CardService.getInstance();
+        await TestTransactionDelegate.transaction(async () => {
+            // given
+            const em = getEntityManagerOrTransactionManager('default');
+
+            const user0 = em.create(User, {
+                socialId: 0,
+                name: 'youngxpepp',
+                profileImageUrl: 'http://',
+            });
+            await em.save(user0);
+
+            // when
+            // then
+            try {
+                const card = await cardService.getCard({ userId: user0.id, cardId: 1 });
+                fail();
+            } catch (error) {
+                expect(error).toBeInstanceOf(EntityNotFoundError);
+            }
+        });
+    });
+
+    test('초대되지 않은 보드의 카드를 조회했을 때 ForbiddenError 발생', async () => {
+        const cardService = CardService.getInstance();
+        await TestTransactionDelegate.transaction(async () => {
+            // given
+            const em = getEntityManagerOrTransactionManager('default');
+
+            const user0 = em.create(User, {
+                socialId: '0',
+                name: 'youngxpepp',
+                profileImageUrl: 'http://',
+            });
+            const user1 = em.create(User, {
+                socialId: '1',
+                name: 'park-sooyeon',
+                profileImageUrl: 'http://',
+            });
+            await em.save([user0, user1]);
+
+            const board0 = em.create(Board, {
+                title: 'board title 0',
+                color: '#FFFFFF',
+                creator: user0,
+            });
+            await em.save(board0);
+
+            const list0 = em.create(List, {
+                title: 'list title 0',
+                position: 0,
+                board: board0,
+                creator: user0,
+            });
+            await em.save(list0);
+
+            const card0 = em.create(Card, {
+                title: 'card title 0',
+                content: 'card content 0',
+                position: 0,
+                dueDate: moment('2020-12-03T09:37:00').format(),
+                list: list0,
+                creator: user0,
+            });
+            await em.save(card0);
+
+            // when
+            // then
+            try {
+                await cardService.getCard({ userId: user1.id, cardId: card0.id });
+                fail();
+            } catch (error) {
+                expect(error).toBeInstanceOf(ForbiddenError);
+            }
+        });
+    });
+
+    test('user0이 만든 본인이 만든 card0 조회', async () => {
+        const cardService = CardService.getInstance();
+        await TestTransactionDelegate.transaction(async () => {
+            // given
+            const em = getEntityManagerOrTransactionManager('default');
+
+            const user0 = em.create(User, {
+                socialId: '0',
+                name: 'youngxpepp',
+                profileImageUrl: 'http://',
+            });
+            const user1 = em.create(User, {
+                socialId: '1',
+                name: 'park-sooyeon',
+                profileImageUrl: 'http://',
+            });
+            await em.save([user0, user1]);
+
+            const board0 = em.create(Board, {
+                title: 'board title 0',
+                color: '#FFFFFF',
+                creator: user0,
+            });
+            await em.save(board0);
+
+            const list0 = em.create(List, {
+                title: 'list title 0',
+                position: 0,
+                board: board0,
+                creator: user0,
+            });
+            await em.save(list0);
+
+            const card0 = em.create(Card, {
+                title: 'card title 0',
+                content: 'card content 0',
+                position: 0,
+                dueDate: moment('2020-12-03T09:37:00').format(),
+                list: list0,
+                creator: user0,
+            });
+            await em.save(card0);
+
+            await em.save(em.create(Invitation, { user: user1, board: board0 }));
+            await em.save(
+                em.create(Member, {
+                    user: user1,
+                    card: card0,
+                }),
+            );
+
+            const comment0 = em.create(Comment, {
+                content: 'hey~',
+                user: user1,
+                card: card0,
+            });
+            await em.save(comment0);
+
+            // when
+            const card = await cardService.getCard({ userId: user0.id, cardId: card0.id });
+
+            // then
+            expect(card).toEqual({
+                id: card0.id,
+                title: card0.title,
+                content: card0.content,
+                dueDate: card0.dueDate,
+                list: {
+                    id: list0.id,
+                    title: list0.title,
+                },
+                board: {
+                    id: board0.id,
+                    title: board0.title,
+                },
+                members: expect.any(Array),
+                comments: expect.any(Array),
+            });
+            expect(card.members).toHaveLength(1);
+            expect(card.members?.[0]).toEqual({
+                id: user1.id,
+                name: user1.name,
+                profileImageUrl: user1.profileImageUrl,
+            });
+            expect(card.comments).toHaveLength(1);
+            expect(card.comments?.[0]).toEqual({
+                id: comment0.id,
+                content: comment0.content,
+                createdAt: moment(comment0.createdAt).tz('Asia/Seoul').format(),
+                user: {
+                    id: user1.id,
+                    name: user1.name,
+                    profileImageUrl: user1.profileImageUrl,
+                },
+            });
+        });
+    });
+});


### PR DESCRIPTION
# 카드 상세 조회 API 구현 완료

## 📎 해당 이슈

이슈 링크 (#189)

## 🛠 구현 내용 

- GET /api/card/{cardId}
- 카드 기본 정보인 id, title, content, dueDate 응답
- 연관 관계 정보인 members, comments, board, list 응답
- 조회하려는 카드가 속한 보드에 초대된 유저만 조회 가능

## 🙋‍ 리뷰어 참고 사항 
- dao에 대한 테스트를 생략했어요. 시간날 때 테스트 작성해봐요
- docker-compose.yml에는 도커를 통해 MySQL 컨테이너를 띄울 수 있도록 했습니다. 로컬 환경에 편의를 제공하기 위함입니다.
