### PR TITLE
CalendarPickerView에 日에 포함된 카드 개수에 따른 색깔 변화 구현

### DIFF
--- a/iOS/AreUDone/AreUDone.xcodeproj/project.pbxproj
+++ b/iOS/AreUDone/AreUDone.xcodeproj/project.pbxproj
@@ -295,6 +295,7 @@
 		BD59A6F1257F3D5A00BF8928 /* CommentEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD59A6F0257F3D5A00BF8928 /* CommentEndPoint.swift */; };
 		BD59A6F8257F514500BF8928 /* MemberUpdateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD59A682257E157000BF8928 /* MemberUpdateViewController.swift */; };
 		BD59A6FC257F514D00BF8928 /* MemberUpdateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD59A688257E163100BF8928 /* MemberUpdateViewModel.swift */; };
+		BD59A701257F7A2A00BF8928 /* MonthCardCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD59A700257F7A2A00BF8928 /* MonthCardCount.swift */; };
 		BDD18AB425653CE5005DF00A /* UIStoryboard+.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD18AB325653CE5005DF00A /* UIStoryboard+.swift */; };
 		BDD18ABD2565449D005DF00A /* SceneCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD18ABC2565449D005DF00A /* SceneCoordinator.swift */; };
 		BDD18AC5256544C6005DF00A /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD18AC4256544C6005DF00A /* Coordinator.swift */; };
@@ -523,6 +524,7 @@
 		BD59A6CB257F180100BF8928 /* TokenParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenParser.swift; sourceTree = "<group>"; };
 		BD59A6D0257F192300BF8928 /* UserIdStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserIdStore.swift; sourceTree = "<group>"; };
 		BD59A6F0257F3D5A00BF8928 /* CommentEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentEndPoint.swift; sourceTree = "<group>"; };
+		BD59A700257F7A2A00BF8928 /* MonthCardCount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthCardCount.swift; sourceTree = "<group>"; };
 		BDD18AB325653CE5005DF00A /* UIStoryboard+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStoryboard+.swift"; sourceTree = "<group>"; };
 		BDD18ABC2565449D005DF00A /* SceneCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneCoordinator.swift; sourceTree = "<group>"; };
 		BDD18AC4256544C6005DF00A /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
@@ -1295,6 +1297,7 @@
 				BD59A6C6257F13E100BF8928 /* UserInfo.swift */,
 				BD59A6CB257F180100BF8928 /* TokenParser.swift */,
 				BD59A6D0257F192300BF8928 /* UserIdStore.swift */,
+				BD59A700257F7A2A00BF8928 /* MonthCardCount.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -1820,6 +1823,7 @@
 				336011EE256D4877009580A1 /* DateStepper.swift in Sources */,
 				BD2AA727256CBE7600EA8791 /* CardCollectionView.swift in Sources */,
 				333BA53B2575FFCC0057ACA4 /* SideBarViewController.swift in Sources */,
+				BD59A701257F7A2A00BF8928 /* MonthCardCount.swift in Sources */,
 				335AC4B4256EA1BB006A5C4A /* BoardListCollectionViewCell.swift in Sources */,
 				333BA5CF25787F290057ACA4 /* ImageService.swift in Sources */,
 				33F2D508257B6AFE008F1E06 /* InvitationTableViewDataSource.swift in Sources */,

--- a/iOS/AreUDone/AreUDone/CalendarPickerScene/CalendarPickerViewCoordinator.swift
+++ b/iOS/AreUDone/AreUDone/CalendarPickerScene/CalendarPickerViewCoordinator.swift
@@ -6,19 +6,22 @@
 //
 
 import UIKit
-
+import NetworkFramework
 
 final class CalendarPickerViewCoordinator: NavigationCoordinator {
   
   private let selectedDate: Date
   var navigationController: UINavigationController?
+  let router: Routable
   
-  init(selectedDate: Date) {
+  init(router: Routable, selectedDate: Date) {
+    self.router = router
     self.selectedDate = selectedDate
   }
   
   func start() -> UIViewController {
-    let viewModel = CalendarPickerViewModel()
+    let cardService = CardService(router: MockRouter(jsonFactory: CardTrueJsonFactory()))
+    let viewModel = CalendarPickerViewModel(cardService: cardService)
     viewModel.selectedDate = selectedDate
     
     let calendarPickerViewController = CalendarPickerViewController(viewModel: viewModel)

--- a/iOS/AreUDone/AreUDone/CalendarPickerScene/View/CalendarDateCollectionViewCell.swift
+++ b/iOS/AreUDone/AreUDone/CalendarPickerScene/View/CalendarDateCollectionViewCell.swift
@@ -33,8 +33,7 @@ final class CalendarDateCollectionViewCell: UICollectionViewCell, Reusable {
   private lazy var cardCountView: UIView = {
     let view = UIView()
     view.translatesAutoresizingMaskIntoConstraints = false
-    view.backgroundColor = .blue
-//    view.isHidden = true
+    view.backgroundColor = .clear
     
     return view
   }()
@@ -59,6 +58,16 @@ final class CalendarDateCollectionViewCell: UICollectionViewCell, Reusable {
     super.init(frame: frame)
 
     configure()
+  }
+  
+  override func prepareForReuse() {
+    super.prepareForReuse()
+    
+    cardCountView.backgroundColor = .clear
+  }
+  
+  func updateCountView(with count: Int) {
+    cardCountView.backgroundColor = cardCountColor(for: count)
   }
 }
 
@@ -127,5 +136,22 @@ private extension CalendarDateCollectionViewCell {
   func applyDefaultStyle(isWithinDisplayedMonth: Bool) {
     numberLabel.textColor = isWithinDisplayedMonth ? .label : .secondaryLabel
     selectionBackgroundView.isHidden = true
+  }
+  
+  func cardCountColor(for count: Int) -> UIColor? {
+    switch count {
+    case 0:
+      break
+    case 1...2:
+      return UIColor(red: 140/255, green: 241/255, blue: 152/255, alpha: 1.0)
+    case 3...5:
+      return UIColor(red: 57/255, green: 187/255, blue: 81/255, alpha: 1.0)
+    case 6...10:
+      return UIColor(red: 42/255, green: 147/255, blue: 62/255, alpha: 1.0)
+    default:
+      return UIColor(red: 28/255, green: 92/255, blue: 43/255, alpha: 1.0)
+    }
+    
+    return nil
   }
 }

--- a/iOS/AreUDone/AreUDone/CalendarPickerScene/View/CalendarDateCollectionViewCell.swift
+++ b/iOS/AreUDone/AreUDone/CalendarPickerScene/View/CalendarDateCollectionViewCell.swift
@@ -29,6 +29,15 @@ final class CalendarDateCollectionViewCell: UICollectionViewCell, Reusable {
     
     return label
   }()
+  
+  private lazy var cardCountView: UIView = {
+    let view = UIView()
+    view.translatesAutoresizingMaskIntoConstraints = false
+    view.backgroundColor = .blue
+//    view.isHidden = true
+    
+    return view
+  }()
 
   var day: Day? {
     didSet {
@@ -61,9 +70,11 @@ private extension CalendarDateCollectionViewCell {
   func configure() {
     addSubview(selectionBackgroundView)
     contentView.addSubview(numberLabel)
+    contentView.addSubview(cardCountView)
 
     configureSelectionBackgroundView()
     configureNumberLabel()
+    configureCardCountView()
   }
   
   func configureNumberLabel() {
@@ -78,7 +89,7 @@ private extension CalendarDateCollectionViewCell {
   func configureSelectionBackgroundView() {
     selectionBackgroundView.translatesAutoresizingMaskIntoConstraints = false
     
-    let size = frame.width - 15
+    let size = frame.width - 20
 
     NSLayoutConstraint.activate([
       selectionBackgroundView.centerYAnchor.constraint(equalTo: numberLabel.centerYAnchor),
@@ -88,6 +99,15 @@ private extension CalendarDateCollectionViewCell {
     ])
     
     selectionBackgroundView.layer.cornerRadius = size / 2
+  }
+  
+  func configureCardCountView() {
+    NSLayoutConstraint.activate([
+      cardCountView.centerXAnchor.constraint(equalTo: numberLabel.centerXAnchor),
+      cardCountView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+      cardCountView.widthAnchor.constraint(equalToConstant: 7),
+      cardCountView.heightAnchor.constraint(equalTo: cardCountView.widthAnchor)
+    ])
   }
   
   func updateSelectionStatus() {

--- a/iOS/AreUDone/AreUDone/CalendarPickerScene/View/CalendarPickerHeaderView.swift
+++ b/iOS/AreUDone/AreUDone/CalendarPickerScene/View/CalendarPickerHeaderView.swift
@@ -14,7 +14,6 @@ final class CalendarPickerHeaderView: UIView {
   private lazy var monthLabel: UILabel = {
     let label = UILabel()
     label.font = UIFont.nanumB(size: 24)
-    label.text = "Month"
     
     return label
   }()

--- a/iOS/AreUDone/AreUDone/CalendarPickerScene/ViewModel/CalendarPickerViewModel.swift
+++ b/iOS/AreUDone/AreUDone/CalendarPickerScene/ViewModel/CalendarPickerViewModel.swift
@@ -32,7 +32,6 @@ final class CalendarPickerViewModel: CalendarPickerViewModelProtocol {
   private lazy var basedate: Date! = selectedDate
   private let cardService: CardServiceProtocol
   private var type = "me"
-  private var currentMonthMetaData: MonthMetadata?
   private var countDictionary = [String: Int]()
   
   private let calendar = Calendar(identifier: .gregorian)
@@ -55,8 +54,8 @@ final class CalendarPickerViewModel: CalendarPickerViewModelProtocol {
   
   func fetchInitialCalendar() {
     let days = daysInMonth(for: selectedDate)
-    fetchCardCount { [unowned self] in
-      initializeCalendarHandler?(days, selectedDate)
+    fetchCardCount {
+      self.initializeCalendarHandler?(days, self.selectedDate)
     }
   }
   
@@ -68,8 +67,8 @@ final class CalendarPickerViewModel: CalendarPickerViewModelProtocol {
     )) ?? basedate
     
     let days = daysInMonth(for: basedate)
-    fetchCardCount { [unowned self] in
-      updateCalendarHandler?(days, basedate)
+    fetchCardCount {
+      self.updateCalendarHandler?(days, self.basedate)
     }
   }
   
@@ -146,7 +145,7 @@ private extension CalendarPickerViewModel {
     guard let monthMetadata = try? monthMetadata(for: baseDate) else {
       preconditionFailure("An error occurred when generating the metadata for \(baseDate)")
     }
-    currentMonthMetaData = monthMetadata
+    
     var days = makeDays(using: monthMetadata) // 이전 달 + 해당 달
     days += makeDaysOfNextMonth(using: days.count, monthMetadata.firstDay) // + 다음 달
     

--- a/iOS/AreUDone/AreUDone/CalendarPickerScene/ViewModel/CalendarPickerViewModel.swift
+++ b/iOS/AreUDone/AreUDone/CalendarPickerScene/ViewModel/CalendarPickerViewModel.swift
@@ -80,11 +80,14 @@ final class CalendarPickerViewModel: CalendarPickerViewModelProtocol {
     let date = selectedDate.toString()
     sendSelectedDateHandler?(date)
   }
+}
+
+
+// MARK: Calendar 계산
+
+private extension CalendarPickerViewModel {
   
-  
-  // MARK: Calendar 계산
-  
-  private func daysInMonth(for baseDate: Date) -> [Day] {
+  func daysInMonth(for baseDate: Date) -> [Day] {
     guard let monthMetadata = try? monthMetadata(for: baseDate) else {
       preconditionFailure("An error occurred when generating the metadata for \(baseDate)")
     }
@@ -95,7 +98,7 @@ final class CalendarPickerViewModel: CalendarPickerViewModelProtocol {
     return days
   }
     
-  private func monthMetadata(for baseDate: Date) throws -> MonthMetadata {
+  func monthMetadata(for baseDate: Date) throws -> MonthMetadata {
     guard let numberOfDaysInMonth = calendar.range(
       of: .day,
       in: .month,
@@ -115,7 +118,7 @@ final class CalendarPickerViewModel: CalendarPickerViewModelProtocol {
       firstDayIndex: firstDayWeekday)
   }
   
-  private func makeDay(
+  func makeDay(
     offsetBy dayOffset: Int,
     for baseDate: Date,
     isWithinDisplayedMonth: Bool
@@ -133,7 +136,7 @@ final class CalendarPickerViewModel: CalendarPickerViewModelProtocol {
     )
   }
   
-  private func makeDays(using monthMetadata: MonthMetadata) -> [Day] {
+  func makeDays(using monthMetadata: MonthMetadata) -> [Day] {
     let numberOfDaysInMonth = monthMetadata.numberOfDays        // 한 달의 일 수
     let firstDayOfMonth = monthMetadata.firstDay                // 해당 달의 첫 번째 날
     let firstDayOfMonthIndex = monthMetadata.firstDayIndex      // 해당 달의 첫 번째 날의 인덱스
@@ -157,7 +160,7 @@ final class CalendarPickerViewModel: CalendarPickerViewModelProtocol {
     return days
   }
   
-  private func makeDaysOfNextMonth(
+  func makeDaysOfNextMonth(
     using counts: Int, _ firstDayOfDisplayedMonth: Date
   ) -> [Day] {
     guard let lastDayInMonth = calendar.date(
@@ -177,7 +180,7 @@ final class CalendarPickerViewModel: CalendarPickerViewModelProtocol {
     return days
   }
   
-  private enum CalendarDataError: Error {
+  enum CalendarDataError: Error {
     case metadataGeneration
   }
 }

--- a/iOS/AreUDone/AreUDone/CalendarPickerScene/ViewModel/CalendarPickerViewModel.swift
+++ b/iOS/AreUDone/AreUDone/CalendarPickerScene/ViewModel/CalendarPickerViewModel.swift
@@ -29,6 +29,7 @@ final class CalendarPickerViewModel: CalendarPickerViewModelProtocol {
   
   var selectedDate: Date!
   private lazy var basedate: Date! = selectedDate
+  private let cardService: CardServiceProtocol
   
   private let calendar = Calendar(identifier: .gregorian)
   
@@ -38,6 +39,12 @@ final class CalendarPickerViewModel: CalendarPickerViewModelProtocol {
     return dateFormatter
   }()
   
+  
+  // MARK:- Initializer
+  
+  init(cardService: CardServiceProtocol) {
+    self.cardService = cardService
+  }
   
   // MARK: - Method
   

--- a/iOS/AreUDone/AreUDone/CalendarScene/CalendarCoordinator.swift
+++ b/iOS/AreUDone/AreUDone/CalendarScene/CalendarCoordinator.swift
@@ -54,7 +54,7 @@ final class CalendarCoordinator: NavigationCoordinator {
 extension CalendarCoordinator {
   
   func didTapOnDate(selectedDate: Date, delegate: CalendarPickerViewControllerDelegate) {
-    calendarPickerCoordinator = CalendarPickerViewCoordinator(selectedDate: selectedDate)
+    calendarPickerCoordinator = CalendarPickerViewCoordinator(router: router, selectedDate: selectedDate)
     calendarPickerCoordinator.navigationController = navigationController
     
     guard let calendarPickerViewController = calendarPickerCoordinator.start()

--- a/iOS/AreUDone/AreUDone/CardDetailScene/CardDetailCoordinator.swift
+++ b/iOS/AreUDone/AreUDone/CardDetailScene/CardDetailCoordinator.swift
@@ -81,7 +81,7 @@ extension CardDetailCoordinator {
   
   func showCalendar(with stringToDate: String, delegate: CalendarPickerViewControllerDelegate) {
     let date = stringToDate.toDateFormat(with: .dash)
-    calendarPickerCoordinator = CalendarPickerViewCoordinator(selectedDate: date)
+    calendarPickerCoordinator = CalendarPickerViewCoordinator(router: router, selectedDate: date)
     calendarPickerCoordinator.navigationController = navigationController
     
     guard let calendarPickerViewController = calendarPickerCoordinator.start()

--- a/iOS/AreUDone/AreUDone/Common/Extension/Date+.swift
+++ b/iOS/AreUDone/AreUDone/Common/Extension/Date+.swift
@@ -9,10 +9,29 @@ import Foundation
 
 extension Date {
   
-  func toString() -> String {
+  func toString(withDividerFormat dividerFormat: String = ".") -> String {
     let dateFormatter = DateFormatter()
-    dateFormatter.dateFormat = "yyyy.MM.dd"
+    dateFormatter.dateFormat = "yyyy\(dividerFormat)MM\(dividerFormat)dd"
     
     return dateFormatter.string(from: self)
+  }
+  
+  func startOfMonth() -> Date? {
+    let calendar = Calendar(identifier: .gregorian)
+    guard
+      let date = calendar.date(bySetting: .day, value: 1, of: self)
+    else { return nil }
+    
+    return calendar.date(byAdding: .month, value: -1, to: date)
+  }
+  
+  func endOfMonth() -> Date? {
+    let calendar = Calendar(identifier: .gregorian)
+    
+    guard
+      let date = calendar.date(bySetting: .day, value: 1, of: self)
+    else { return nil }
+    
+    return calendar.date(byAdding: .day, value: -1, to: date)
   }
 }

--- a/iOS/AreUDone/AreUDone/Common/Mock/CardJsonFactory.swift
+++ b/iOS/AreUDone/AreUDone/Common/Mock/CardJsonFactory.swift
@@ -191,6 +191,38 @@ struct CardTrueJsonFactory: JsonFactory {
                 }
             }
             """.data(using: .utf8)
+      
+    case CardEndPoint.fetchCardsCount:
+      return """
+            {
+                "cardCounts" : [
+                      {
+                          "dueDate": "2020-01-01",
+                          "count": 1
+                      },
+                      {
+                          "dueDate": "2020-01-02",
+                          "count": 3
+                      },
+                      {
+                          "dueDate": "2020-01-15",
+                          "count": 2
+                      },
+                      {
+                          "dueDate": "2020-01-21",
+                          "count": 5
+                      },
+                      {
+                          "dueDate": "2020-01-23",
+                          "count": 7
+                      },
+                      {
+                          "dueDate": "2020-01-26",
+                          "count": 11
+                      }
+                ]
+            }
+            """.data(using: .utf8)
     default:
       return nil
     }
@@ -209,17 +241,3 @@ struct CardFalseJsonFactory: JsonFactory {
     }
   }
 }
-
-/*
- 
- {
-     "id": 0,
-     "content": "화이팅!123",
-     "createdAt": "2020-12-02",
-     "user": {
-         "id": 0,
-         "name": "서명렬",
-         "profileImageUrl": ""
-     }
- },
- */

--- a/iOS/AreUDone/AreUDone/Common/Model/MonthCardCount.swift
+++ b/iOS/AreUDone/AreUDone/Common/Model/MonthCardCount.swift
@@ -1,0 +1,17 @@
+//
+//  MonthCardCount.swift
+//  AreUDone
+//
+//  Created by 서명렬 on 2020/12/08.
+//
+
+import Foundation
+
+struct MonthCardCount: Codable {
+  let cardCount: [DailyCardCount]
+  
+  struct DailyCardCount: Codable {
+    let dueDate: String
+    let count: Int
+  }
+}

--- a/iOS/AreUDone/AreUDone/Common/Model/MonthCardCount.swift
+++ b/iOS/AreUDone/AreUDone/Common/Model/MonthCardCount.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct MonthCardCount: Codable {
-  let cardCount: [DailyCardCount]
+  let cardCounts: [DailyCardCount]
   
   struct DailyCardCount: Codable {
     let dueDate: String

--- a/iOS/AreUDone/AreUDone/Service/CardService/CardEndPoint.swift
+++ b/iOS/AreUDone/AreUDone/Service/CardService/CardEndPoint.swift
@@ -22,6 +22,7 @@ enum CardEndPoint {
         dueDate: String?
        )
   case updateCardMember(id: Int, userIds: [Int])
+  case fetchCardsCount(startDate: String, endDate: String, member: String?)
 }
 
 extension CardEndPoint: EndPointable {
@@ -38,6 +39,9 @@ extension CardEndPoint: EndPointable {
       
     case .updateCardMember(let id, _):
       return "\(APICredentials.ip)/api/card/\(id)/member"
+      
+    case .fetchCardsCount:
+      return "\(APICredentials.ip)/api/card/count"
     }
   }
   
@@ -59,6 +63,13 @@ extension CardEndPoint: EndPointable {
       
     case .updateCardMember:
       return nil
+      
+    case .fetchCardsCount(let startDate, let endDate, let member):
+      var value = "startdate:" + startDate + " " + "enddate:" + endDate
+      if let member = member {
+        value += " " + member
+      }
+      return ["q": value]
     }
   }
   
@@ -75,6 +86,9 @@ extension CardEndPoint: EndPointable {
       
     case .updateCardMember:
       return .put
+      
+    case .fetchCardsCount:
+      return .get
     }
   }
   

--- a/iOS/AreUDone/AreUDone/Service/CardService/CardService.swift
+++ b/iOS/AreUDone/AreUDone/Service/CardService/CardService.swift
@@ -21,6 +21,12 @@ protocol CardServiceProtocol {
     completionHandler: @escaping ((Result<Void, APIError>) -> Void)
   )
   func updateCardMember(id: Int, userIds: [Int], completionHandler: @escaping ((Result<Void, APIError>) -> Void))
+  func fetchCardsCount(
+    startDate: String,
+    endDate: String,
+    member: String?,
+    completionHandler: @escaping ((Result<MonthCardCount, APIError>) -> Void)
+  )
 }
 
 extension CardServiceProtocol {
@@ -96,6 +102,21 @@ class CardService: CardServiceProtocol {
   
   func updateCardMember(id: Int, userIds: [Int], completionHandler: @escaping ((Result<Void, APIError>) -> Void)) {
     router.request(route: CardEndPoint.updateCardMember(id: id, userIds: userIds)) { (result: Result<Void, APIError>) in
+      completionHandler(result)
+    }
+  }
+  
+  func fetchCardsCount(
+    startDate: String,
+    endDate: String,
+    member: String?,
+    completionHandler: @escaping ((Result<MonthCardCount, APIError>) -> Void)
+  ) {
+    router.request(route: CardEndPoint.fetchCardsCount(
+      startDate: startDate,
+      endDate: endDate,
+      member: member
+    )) { (result: Result<MonthCardCount, APIError>) in
       completionHandler(result)
     }
   }


### PR DESCRIPTION
# CalendarPickerView에 日에 포함된 카드 개수에 따른 색깔 변화 구현

## 📎 해당 이슈
#227 

## 🛠 구현 내용 

- CalendarPicker 화면에서 요일별 card 개수에 따라서 색상 표시

## 🙋‍ 리뷰어 참고 사항 
- collectionView가 dataSource를 통해 업데이트 되기 전에 card 개수를 가져와야하는데,
비동기적인 부분이다 보니 개수를 가져오기전에 cell이 업데이트 되서 표시가 안되는 문제가 있었습니다.
card의 개수를 가져온 후 cell을 업데이트 하기 위해 fetchCardCount() 메서드의 completionHandler로 업데이트 handler를 넣게 됐습니다!
리뷰 부탁드립니다! 힘들었슴다! ㅎㅎ
