### PR TITLE
보드 목록 / 상세 화면의 리스트 기능 나머지 구현

### DIFF
--- a/iOS/AreUDone/AreUDone.xcodeproj/project.pbxproj
+++ b/iOS/AreUDone/AreUDone.xcodeproj/project.pbxproj
@@ -189,6 +189,7 @@
 		33F2D551257DE9C7008F1E06 /* BoardAddTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F2D550257DE9C7008F1E06 /* BoardAddTableView.swift */; };
 		33F2D55F257DF349008F1E06 /* BoardColorTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F2D55E257DF349008F1E06 /* BoardColorTableViewCell.swift */; };
 		33F2D567257E2389008F1E06 /* BoardAddTableViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F2D566257E2389008F1E06 /* BoardAddTableViewDataSource.swift */; };
+		33F2D6A2257F41EB008F1E06 /* BoardDetailCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F2D6A1257F41EA008F1E06 /* BoardDetailCollectionView.swift */; };
 		33F66CE92567A17C00959401 /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F66CE82567A17C00959401 /* UIViewController+.swift */; };
 		BD2AA727256CBE7600EA8791 /* CardCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2AA726256CBE7600EA8791 /* CardCollectionView.swift */; };
 		BD2AA72D256CBEB400EA8791 /* CardCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2AA72B256CBEB400EA8791 /* CardCollectionViewCell.swift */; };
@@ -402,6 +403,7 @@
 		33F2D550257DE9C7008F1E06 /* BoardAddTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardAddTableView.swift; sourceTree = "<group>"; };
 		33F2D55E257DF349008F1E06 /* BoardColorTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardColorTableViewCell.swift; sourceTree = "<group>"; };
 		33F2D566257E2389008F1E06 /* BoardAddTableViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardAddTableViewDataSource.swift; sourceTree = "<group>"; };
+		33F2D6A1257F41EA008F1E06 /* BoardDetailCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardDetailCollectionView.swift; sourceTree = "<group>"; };
 		33F66CE82567A17C00959401 /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
 		BD2AA726256CBE7600EA8791 /* CardCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardCollectionView.swift; sourceTree = "<group>"; };
 		BD2AA72B256CBEB400EA8791 /* CardCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -655,6 +657,7 @@
 		335AC512256FDC91006A5C4A /* CollectionView */ = {
 			isa = PBXGroup;
 			children = (
+				33F2D6A1257F41EA008F1E06 /* BoardDetailCollectionView.swift */,
 				333BA4FF2574ABA80057ACA4 /* BoardDetailFooterView.swift */,
 				335AC51B256FDDAB006A5C4A /* BoardDetailCollectionViewCell.swift */,
 				33638DED25739971006033CF /* ListCollectionView.swift */,
@@ -1603,6 +1606,7 @@
 				33638DE12573956F006033CF /* ListFooterView.swift in Sources */,
 				BDE27E2C256B9215002308B9 /* UITableView+.swift in Sources */,
 				BD59A6522579D2D600BF8928 /* User.swift in Sources */,
+				33F2D6A2257F41EB008F1E06 /* BoardDetailCollectionView.swift in Sources */,
 				335AC50B256F8D28006A5C4A /* BoardDetailViewModel.swift in Sources */,
 				33F2D53D257DDD42008F1E06 /* BoardAddViewModel.swift in Sources */,
 				33638DFE2573C660006033CF /* UIEdgeInsets+.swift in Sources */,

--- a/iOS/AreUDone/AreUDone.xcodeproj/project.pbxproj
+++ b/iOS/AreUDone/AreUDone.xcodeproj/project.pbxproj
@@ -124,6 +124,7 @@
 		33638EC42573F99D006033CF /* BoardListCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 335AC4B3256EA1BB006A5C4A /* BoardListCollectionViewCell.swift */; };
 		3373A4952578DC7200D92CC0 /* UIView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3373A4942578DC7200D92CC0 /* UIView+.swift */; };
 		3373A49A2578DEC300D92CC0 /* MemberFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3373A4992578DEC300D92CC0 /* MemberFooterView.swift */; };
+		338316F2258078900040A467 /* NotificationName+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 338316F1258078900040A467 /* NotificationName+.swift */; };
 		338364592565574E00F92EE4 /* InitCoordinatorFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 338364582565574E00F92EE4 /* InitCoordinatorFactory.swift */; };
 		338364612565586800F92EE4 /* SigninViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 338364602565586800F92EE4 /* SigninViewModel.swift */; };
 		3383647925660EDE00F92EE4 /* NetworkFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 3383647725660EDE00F92EE4 /* NetworkFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -172,7 +173,6 @@
 		33F2D494257A2338008F1E06 /* SideBarCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F2D493257A2338008F1E06 /* SideBarCollectionView.swift */; };
 		33F2D49C257A31DF008F1E06 /* ImageTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F2D49B257A31DF008F1E06 /* ImageTitleView.swift */; };
 		33F2D4A8257A3F6C008F1E06 /* MemberCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F2D4A7257A3F6C008F1E06 /* MemberCollectionView.swift */; };
-		33F2D4B9257A8D0A008F1E06 /* MembersCollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F2D4B8257A8D0A008F1E06 /* MembersCollectionViewDataSource.swift */; };
 		33F2D4C7257A92DA008F1E06 /* SideBarCollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F2D4C6257A92DA008F1E06 /* SideBarCollectionViewDataSource.swift */; };
 		33F2D4DD257B3F47008F1E06 /* InvitationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F2D4DC257B3F47008F1E06 /* InvitationCoordinator.swift */; };
 		33F2D4E6257B4079008F1E06 /* Invitation.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 33F2D4E5257B4079008F1E06 /* Invitation.storyboard */; };
@@ -191,6 +191,9 @@
 		33F2D567257E2389008F1E06 /* BoardAddTableViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F2D566257E2389008F1E06 /* BoardAddTableViewDataSource.swift */; };
 		33F2D6A2257F41EB008F1E06 /* BoardDetailCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F2D6A1257F41EA008F1E06 /* BoardDetailCollectionView.swift */; };
 		33F2D6AA257F56C8008F1E06 /* ListEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F2D6A9257F56C8008F1E06 /* ListEndPoint.swift */; };
+		33F2D6BD257F7635008F1E06 /* MembersCollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F2D6BC257F7635008F1E06 /* MembersCollectionViewDataSource.swift */; };
+		33F2D6C5257F7D9F008F1E06 /* BoardDetailCollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F2D6C4257F7D9F008F1E06 /* BoardDetailCollectionViewDataSource.swift */; };
+		33F2D6CA257F838D008F1E06 /* ListCollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F2D6C9257F838D008F1E06 /* ListCollectionViewDataSource.swift */; };
 		33F66CE92567A17C00959401 /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F66CE82567A17C00959401 /* UIViewController+.swift */; };
 		BD2AA727256CBE7600EA8791 /* CardCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2AA726256CBE7600EA8791 /* CardCollectionView.swift */; };
 		BD2AA72D256CBEB400EA8791 /* CardCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2AA72B256CBEB400EA8791 /* CardCollectionViewCell.swift */; };
@@ -353,6 +356,7 @@
 		33638E0D2573F5D6006033CF /* ListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListViewModelTests.swift; sourceTree = "<group>"; };
 		3373A4942578DC7200D92CC0 /* UIView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+.swift"; sourceTree = "<group>"; };
 		3373A4992578DEC300D92CC0 /* MemberFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberFooterView.swift; sourceTree = "<group>"; };
+		338316F1258078900040A467 /* NotificationName+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotificationName+.swift"; sourceTree = "<group>"; };
 		338364582565574E00F92EE4 /* InitCoordinatorFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InitCoordinatorFactory.swift; sourceTree = "<group>"; };
 		338364602565586800F92EE4 /* SigninViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SigninViewModel.swift; path = AreUDone/SignInScene/ViewModel/SigninViewModel.swift; sourceTree = SOURCE_ROOT; };
 		3383647525660EDE00F92EE4 /* NetworkFramework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = NetworkFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -387,7 +391,6 @@
 		33F2D493257A2338008F1E06 /* SideBarCollectionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SideBarCollectionView.swift; sourceTree = "<group>"; };
 		33F2D49B257A31DF008F1E06 /* ImageTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageTitleView.swift; sourceTree = "<group>"; };
 		33F2D4A7257A3F6C008F1E06 /* MemberCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberCollectionView.swift; sourceTree = "<group>"; };
-		33F2D4B8257A8D0A008F1E06 /* MembersCollectionViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MembersCollectionViewDataSource.swift; sourceTree = "<group>"; };
 		33F2D4C6257A92DA008F1E06 /* SideBarCollectionViewDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SideBarCollectionViewDataSource.swift; sourceTree = "<group>"; };
 		33F2D4DC257B3F47008F1E06 /* InvitationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvitationCoordinator.swift; sourceTree = "<group>"; };
 		33F2D4E5257B4079008F1E06 /* Invitation.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Invitation.storyboard; sourceTree = "<group>"; };
@@ -406,6 +409,9 @@
 		33F2D566257E2389008F1E06 /* BoardAddTableViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardAddTableViewDataSource.swift; sourceTree = "<group>"; };
 		33F2D6A1257F41EA008F1E06 /* BoardDetailCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardDetailCollectionView.swift; sourceTree = "<group>"; };
 		33F2D6A9257F56C8008F1E06 /* ListEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListEndPoint.swift; sourceTree = "<group>"; };
+		33F2D6BC257F7635008F1E06 /* MembersCollectionViewDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MembersCollectionViewDataSource.swift; sourceTree = "<group>"; };
+		33F2D6C4257F7D9F008F1E06 /* BoardDetailCollectionViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardDetailCollectionViewDataSource.swift; sourceTree = "<group>"; };
+		33F2D6C9257F838D008F1E06 /* ListCollectionViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListCollectionViewDataSource.swift; sourceTree = "<group>"; };
 		33F66CE82567A17C00959401 /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
 		BD2AA726256CBE7600EA8791 /* CardCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardCollectionView.swift; sourceTree = "<group>"; };
 		BD2AA72B256CBEB400EA8791 /* CardCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -569,7 +575,7 @@
 				333BA56725769F9F0057ACA4 /* SideBarCollectionViewActivityCell.swift */,
 				333BA59E2577BB570057ACA4 /* SideBarCollectionViewMembersCell.swift */,
 				33F2D4A7257A3F6C008F1E06 /* MemberCollectionView.swift */,
-				33F2D4B8257A8D0A008F1E06 /* MembersCollectionViewDataSource.swift */,
+				33F2D6BC257F7635008F1E06 /* MembersCollectionViewDataSource.swift */,
 				3373A4992578DEC300D92CC0 /* MemberFooterView.swift */,
 				333BA5A62577C0440057ACA4 /* MemberCell.swift */,
 			);
@@ -660,9 +666,11 @@
 			isa = PBXGroup;
 			children = (
 				33F2D6A1257F41EA008F1E06 /* BoardDetailCollectionView.swift */,
+				33F2D6C4257F7D9F008F1E06 /* BoardDetailCollectionViewDataSource.swift */,
 				333BA4FF2574ABA80057ACA4 /* BoardDetailFooterView.swift */,
 				335AC51B256FDDAB006A5C4A /* BoardDetailCollectionViewCell.swift */,
 				33638DED25739971006033CF /* ListCollectionView.swift */,
+				33F2D6C9257F838D008F1E06 /* ListCollectionViewDataSource.swift */,
 				335AC52D256FE7C7006A5C4A /* ListCollectionViewCell.swift */,
 				33638DE52573958A006033CF /* ListHeaderView.swift */,
 				33638DE02573956F006033CF /* ListFooterView.swift */,
@@ -1214,6 +1222,7 @@
 				BDEA7BEF25763AB300CF6B11 /* UIAlertController+.swift */,
 				BD59A61325787D4E00BF8928 /* UIFont+.swift */,
 				3373A4942578DC7200D92CC0 /* UIView+.swift */,
+				338316F1258078900040A467 /* NotificationName+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -1556,17 +1565,18 @@
 				BD2AA80A256F8B5900EA8791 /* CommentCollectionView.swift in Sources */,
 				BD2AA80F256F8B6C00EA8791 /* CommentCollectionViewCell.swift in Sources */,
 				BDEA7BD82576246B00CF6B11 /* ContentInputViewController.swift in Sources */,
+				33F2D6CA257F838D008F1E06 /* ListCollectionViewDataSource.swift in Sources */,
 				BDD18AC5256544C6005DF00A /* Coordinator.swift in Sources */,
 				BD2AA7A1256DF8E400EA8791 /* CardDetailViewController.swift in Sources */,
 				BD2AA7C3256E3D3600EA8791 /* CardDetail.swift in Sources */,
 				3373A49A2578DEC300D92CC0 /* MemberFooterView.swift in Sources */,
 				335AC4E6256F7988006A5C4A /* BoardListJsonFactory.swift in Sources */,
 				336011FE256D5CFE009580A1 /* String+.swift in Sources */,
-				33F2D4B9257A8D0A008F1E06 /* MembersCollectionViewDataSource.swift in Sources */,
 				33F2D4F8257B582C008F1E06 /* InvitationTableViewCell.swift in Sources */,
 				3360122A256E5022009580A1 /* BoardListCoordinator.swift in Sources */,
 				33F2D4EB257B40A1008F1E06 /* InvitationViewController.swift in Sources */,
 				BDEA7BEB2576385000CF6B11 /* AlertFactory.swift in Sources */,
+				33F2D6BD257F7635008F1E06 /* MembersCollectionViewDataSource.swift in Sources */,
 				BDD18ABD2565449D005DF00A /* SceneCoordinator.swift in Sources */,
 				3360119A256CBEEA009580A1 /* MonthMetadata.swift in Sources */,
 				33F2D4F0257B41CE008F1E06 /* InvitationViewModel.swift in Sources */,
@@ -1634,6 +1644,7 @@
 				33F2D4C7257A92DA008F1E06 /* SideBarCollectionViewDataSource.swift in Sources */,
 				333BA578257775950057ACA4 /* BoardDetailJsonFactory.swift in Sources */,
 				333BA5912577A5D30057ACA4 /* SideBarHeaderView.swift in Sources */,
+				33F2D6C5257F7D9F008F1E06 /* BoardDetailCollectionViewDataSource.swift in Sources */,
 				3360124F256E58F7009580A1 /* TabbarItemContentsFactory.swift in Sources */,
 				33EE01802568EE7E003D3221 /* CalendarCoordinator.swift in Sources */,
 				336010C8256B78CE009580A1 /* CardEndPoint.swift in Sources */,
@@ -1644,6 +1655,7 @@
 				333BA587257792690057ACA4 /* ActivityEndPoint.swift in Sources */,
 				33F2D49C257A31DF008F1E06 /* ImageTitleView.swift in Sources */,
 				335AC4AF256E9A6B006A5C4A /* Board.swift in Sources */,
+				338316F2258078900040A467 /* NotificationName+.swift in Sources */,
 				33638DE62573958B006033CF /* ListHeaderView.swift in Sources */,
 				333BA56825769F9F0057ACA4 /* SideBarCollectionViewActivityCell.swift in Sources */,
 				BD59A64D2579D1C100BF8928 /* UserJsonFactory.swift in Sources */,

--- a/iOS/AreUDone/AreUDone.xcodeproj/project.pbxproj
+++ b/iOS/AreUDone/AreUDone.xcodeproj/project.pbxproj
@@ -190,6 +190,7 @@
 		33F2D55F257DF349008F1E06 /* BoardColorTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F2D55E257DF349008F1E06 /* BoardColorTableViewCell.swift */; };
 		33F2D567257E2389008F1E06 /* BoardAddTableViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F2D566257E2389008F1E06 /* BoardAddTableViewDataSource.swift */; };
 		33F2D6A2257F41EB008F1E06 /* BoardDetailCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F2D6A1257F41EA008F1E06 /* BoardDetailCollectionView.swift */; };
+		33F2D6AA257F56C8008F1E06 /* ListEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F2D6A9257F56C8008F1E06 /* ListEndPoint.swift */; };
 		33F66CE92567A17C00959401 /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F66CE82567A17C00959401 /* UIViewController+.swift */; };
 		BD2AA727256CBE7600EA8791 /* CardCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2AA726256CBE7600EA8791 /* CardCollectionView.swift */; };
 		BD2AA72D256CBEB400EA8791 /* CardCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2AA72B256CBEB400EA8791 /* CardCollectionViewCell.swift */; };
@@ -404,6 +405,7 @@
 		33F2D55E257DF349008F1E06 /* BoardColorTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardColorTableViewCell.swift; sourceTree = "<group>"; };
 		33F2D566257E2389008F1E06 /* BoardAddTableViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardAddTableViewDataSource.swift; sourceTree = "<group>"; };
 		33F2D6A1257F41EA008F1E06 /* BoardDetailCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardDetailCollectionView.swift; sourceTree = "<group>"; };
+		33F2D6A9257F56C8008F1E06 /* ListEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListEndPoint.swift; sourceTree = "<group>"; };
 		33F66CE82567A17C00959401 /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
 		BD2AA726256CBE7600EA8791 /* CardCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardCollectionView.swift; sourceTree = "<group>"; };
 		BD2AA72B256CBEB400EA8791 /* CardCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -703,6 +705,7 @@
 		336010FB256B8FAB009580A1 /* ListService */ = {
 			isa = PBXGroup;
 			children = (
+				33F2D6A9257F56C8008F1E06 /* ListEndPoint.swift */,
 				BDD18B3925664057005DF00A /* ListService.swift */,
 			);
 			path = ListService;
@@ -1615,6 +1618,7 @@
 				BDD18B342566403E005DF00A /* BoardService.swift in Sources */,
 				333BA59F2577BB570057ACA4 /* SideBarCollectionViewMembersCell.swift in Sources */,
 				BD2AA8A02574A3B200EA8791 /* CardDetailContentLabel.swift in Sources */,
+				33F2D6AA257F56C8008F1E06 /* ListEndPoint.swift in Sources */,
 				333BA4F1257496B10057ACA4 /* CustomBarButtonItem.swift in Sources */,
 				33F2D52A257DDC70008F1E06 /* BoardAddCoordinator.swift in Sources */,
 				3360118C256CBEA1009580A1 /* CalendarPickerHeaderView.swift in Sources */,

--- a/iOS/AreUDone/AreUDone/BoardAddScene/View/BoardAddViewController.swift
+++ b/iOS/AreUDone/AreUDone/BoardAddScene/View/BoardAddViewController.swift
@@ -103,7 +103,9 @@ extension BoardAddViewController {
     }
     
     viewModel.bindingDismiss { [weak self] in
-      self?.coordinator?.dismiss()
+      DispatchQueue.main.async {
+        self?.coordinator?.dismiss()
+      }
     }
   }
 }

--- a/iOS/AreUDone/AreUDone/BoardAddScene/View/BoardColorTableViewCell.swift
+++ b/iOS/AreUDone/AreUDone/BoardAddScene/View/BoardColorTableViewCell.swift
@@ -75,7 +75,7 @@ final class BoardColorTableViewCell: UITableViewCell, Reusable {
   
   func update(with colorAsString: String) {
     colorInfoLabel.text = colorAsString
-    colorImageView.backgroundColor = colorAsString.hexStringToUIColor()
+    colorImageView.backgroundColor = colorAsString.toUIColor()
   }
 }
 

--- a/iOS/AreUDone/AreUDone/BoardAddScene/ViewModel/BoardAddViewModel.swift
+++ b/iOS/AreUDone/AreUDone/BoardAddScene/ViewModel/BoardAddViewModel.swift
@@ -73,6 +73,7 @@ final class BoardAddViewModel: BoardAddViewModelProtocol {
       switch result {
       case .success:
         self.dismissHandler?()
+        
       case .failure(let error):
         print(error)
       }

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/BoardDetailCoordinator.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/BoardDetailCoordinator.swift
@@ -14,9 +14,11 @@ final class BoardDetailCoordinator: NavigationCoordinator {
   
   var navigationController: UINavigationController?
   private var invitationCoordinator: NavigationCoordinator!
+  private var cardDetailCoordinator: NavigationCoordinator!
+
   private let boardId: Int
-  
   private let router: Routable
+  
   private var storyboard: UIStoryboard {
     UIStoryboard.load(storyboard: .boardDetail)
   }
@@ -96,5 +98,17 @@ extension BoardDetailCoordinator {
     
     navigationController?.present(subNavigationController, animated: true)
   }
+  
+  
+  func pushToCardDetail(of cardId: Int) {
+    cardDetailCoordinator = CardDetailCoordinator(id: cardId, router: self.router)
+    cardDetailCoordinator.navigationController = navigationController
+    
+    let cardDetailViewController = cardDetailCoordinator.start()
+    cardDetailViewController.hidesBottomBarWhenPushed = true
+    
+    navigationController?.pushViewController(cardDetailViewController, animated: true)
+  }
 }
+
 

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/BoardDetailCoordinator.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/BoardDetailCoordinator.swift
@@ -15,7 +15,7 @@ final class BoardDetailCoordinator: NavigationCoordinator {
   var navigationController: UINavigationController?
   private var invitationCoordinator: NavigationCoordinator!
   private let boardId: Int
-
+  
   // TODO: Router 구체 타입이 아니라 이전 Coordinator 에서 넘겨주도록 변경
   //  private let router: Routable
   private var storyboard: UIStoryboard {
@@ -38,10 +38,17 @@ final class BoardDetailCoordinator: NavigationCoordinator {
               guard let self = self else { return UIViewController()}
               
               let boardService = BoardService(router: MockRouter(jsonFactory: BoardDetailTrueJsonFactory()))
+              let listService = ListService(router: Router())
+              let cardService = CardService(router: Router())
               let activityService = ActivityService(router: MockRouter(jsonFactory: ActivityTrueJsonFactory()))
               let imageService = ImageService(router: Router()) // TODO: Router 구체 타입이 아니라 이전 Coordinator 에서 넘겨주도록 변경
               
-              let boardDetailViewModel = BoardDetailViewModel(boardService: boardService, boardId: self.boardId)
+              let boardDetailViewModel = BoardDetailViewModel(
+                boardService: boardService,
+                listService: listService,
+                cardService: cardService,
+                boardId: self.boardId
+              )
               
               let sideBarViewModel = SideBarViewModel(
                 boardService: boardService,

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/BoardDetailCoordinator.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/BoardDetailCoordinator.swift
@@ -16,8 +16,7 @@ final class BoardDetailCoordinator: NavigationCoordinator {
   private var invitationCoordinator: NavigationCoordinator!
   private let boardId: Int
   
-  // TODO: Router 구체 타입이 아니라 이전 Coordinator 에서 넘겨주도록 변경
-  //  private let router: Routable
+  private let router: Routable
   private var storyboard: UIStoryboard {
     UIStoryboard.load(storyboard: .boardDetail)
   }
@@ -25,7 +24,8 @@ final class BoardDetailCoordinator: NavigationCoordinator {
   
   // MARK: - Initializer
   
-  init(boardId: Int) {
+  init(router: Routable, boardId: Int) {
+    self.router = router
     self.boardId = boardId
   }
   
@@ -37,11 +37,11 @@ final class BoardDetailCoordinator: NavigationCoordinator {
             identifier: BoardDetailViewController.identifier, creator: { [weak self] coder in
               guard let self = self else { return UIViewController()}
               
-              let boardService = BoardService(router: MockRouter(jsonFactory: BoardDetailTrueJsonFactory()))
-              let listService = ListService(router: Router())
-              let cardService = CardService(router: Router())
+              let boardService = BoardService(router: self.router)
+              let listService = ListService(router: self.router)
+              let cardService = CardService(router: self.router)
               let activityService = ActivityService(router: MockRouter(jsonFactory: ActivityTrueJsonFactory()))
-              let imageService = ImageService(router: Router()) // TODO: Router 구체 타입이 아니라 이전 Coordinator 에서 넘겨주도록 변경
+              let imageService = ImageService(router: self.router)
               
               let boardDetailViewModel = BoardDetailViewModel(
                 boardService: boardService,

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/View/AddOrCancelView.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/View/AddOrCancelView.swift
@@ -9,7 +9,7 @@ import UIKit
 
 protocol AddOrCancelViewDelegate: AnyObject {
   
-  func addButtonTapped(text: String)
+  func addButtonTapped(listTitle: String)
   func cancelButtonTapped()
 }
 
@@ -72,7 +72,7 @@ final class AddOrCancelView: UIView {
   // MARK: - Method
   
   @objc private func addButtonTapped() {
-    delegate?.addButtonTapped(text: textFieldView.text ?? "")
+    delegate?.addButtonTapped(listTitle: textFieldView.text ?? "")
   }
   
   @objc private func cancelButtonTapped() {

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/View/CollectionView/BoardDetailCollectionView.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/View/CollectionView/BoardDetailCollectionView.swift
@@ -1,0 +1,45 @@
+//
+//  BoardDetailCollectionView.swift
+//  AreUDone
+//
+//  Created by a1111 on 2020/12/08.
+//
+
+import UIKit
+
+final class BoardDetailCollectionView: UICollectionView {
+  
+  // MARK: - Initializer
+  
+  required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    
+    configure()
+  }
+  
+  override init(frame: CGRect, collectionViewLayout layout: UICollectionViewLayout) {
+    super.init(frame: frame, collectionViewLayout: layout)
+    
+    configure()
+  }
+}
+
+// MARK: - Extension Configure Method
+
+private extension BoardDetailCollectionView {
+  
+  func configure() {
+    configureView()
+  }
+  
+  func configureView() {
+    backgroundColor = .clear
+    showsHorizontalScrollIndicator = false
+    decelerationRate = UIScrollView.DecelerationRate.fast
+    
+    register(BoardDetailCollectionViewCell.self)
+    registerFooterView(BoardDetailFooterView.self)
+  }
+}
+
+

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/View/CollectionView/BoardDetailCollectionView.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/View/CollectionView/BoardDetailCollectionView.swift
@@ -37,6 +37,10 @@ private extension BoardDetailCollectionView {
     showsHorizontalScrollIndicator = false
     decelerationRate = UIScrollView.DecelerationRate.fast
     
+    registerCell()
+  }
+  
+  func registerCell() {
     register(BoardDetailCollectionViewCell.self)
     registerFooterView(BoardDetailFooterView.self)
   }

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/View/CollectionView/BoardDetailCollectionViewCell.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/View/CollectionView/BoardDetailCollectionViewCell.swift
@@ -13,26 +13,18 @@ final class BoardDetailCollectionViewCell: UICollectionViewCell, Reusable {
   // MARK: - Property
   
   private var viewModel: ListViewModelProtocol!
+  private var dataSource: UICollectionViewDataSource!
   
   private lazy var collectionView: ListCollectionView = {
     let flowLayout = UICollectionViewFlowLayout()
-  
-    flowLayout.headerReferenceSize = CGSize(width: bounds.width, height: 45)
-    flowLayout.footerReferenceSize = CGSize(width: bounds.width, height: 45)
-    flowLayout.itemSize = CGSize(width: bounds.width - 40, height: 40)
     
-    flowLayout.sectionInset = UIEdgeInsets.sameInset(inset: 10)
-   
-    flowLayout.sectionHeadersPinToVisibleBounds = true
-    flowLayout.sectionFootersPinToVisibleBounds = true
-    
-    let collectionView = ListCollectionView(frame: .zero, collectionViewLayout: flowLayout)
+    let collectionView = ListCollectionView(frame: bounds, collectionViewLayout: flowLayout)
     collectionView.translatesAutoresizingMaskIntoConstraints = false
     collectionView.contentInset = UIEdgeInsets.sameInset(inset: 5)
     
     return collectionView
   }()
-  
+  private var drop = true
   
   // MARK: - Initializer
   
@@ -48,11 +40,21 @@ final class BoardDetailCollectionViewCell: UICollectionViewCell, Reusable {
     configure()
   }
   
+  override func prepareForReuse() {
+    super.prepareForReuse()
+    
+    collectionView.reloadData()
+  }
  
   // MARK: - Method
 
-  func update(with viewModel: ListViewModelProtocol) {
+  func update(
+    with viewModel: ListViewModelProtocol,
+    dataSource: UICollectionViewDataSource
+  ) {
     self.viewModel = viewModel
+    self.dataSource = dataSource
+    collectionView.dataSource = dataSource
     
     collectionView.reloadData()
   }
@@ -67,11 +69,11 @@ private extension BoardDetailCollectionViewCell {
     addSubview(collectionView)
 
     configureCollectionView()
+    configureNotification()
   }
   
   func configureCollectionView() {
     collectionView.delegate = self
-    collectionView.dataSource = self
     
     collectionView.dragInteractionEnabled = true
     collectionView.dragDelegate = self
@@ -84,48 +86,17 @@ private extension BoardDetailCollectionViewCell {
       collectionView.trailingAnchor.constraint(equalTo: trailingAnchor)
     ])
   }
-}
-
-
-// MARK: - Extension UICollectionView DataSource
-
-extension BoardDetailCollectionViewCell: UICollectionViewDataSource {
-  func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-    return viewModel.numberOfCards()
-  }
   
-  func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-    let cell: ListCollectionViewCell = collectionView.dequeueReusableCell(forIndexPath: indexPath)
-    
-    cell.update(with: viewModel.fetchCard(at: indexPath.row))
-    
-    return cell
+  func configureNotification() {
+    NotificationCenter.default.addObserver(self, selector: #selector(listWillDragged), name: Notification.Name.listWillDragged, object: nil)
+    NotificationCenter.default.addObserver(self, selector: #selector(listDidDragged), name: Notification.Name.listDidDragged, object: nil)
   }
 }
 
 
 // MARK: - Extension UICollectionView Delegate
 
-extension BoardDetailCollectionViewCell: UICollectionViewDelegate {
-  
-  func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
-    switch kind {
-    case UICollectionView.elementKindSectionHeader:
-      let headerView: ListHeaderView = collectionView.dequeReusableHeaderView(forIndexPath: indexPath)
-      
-      headerView.update(with: viewModel)
-      
-      return headerView
-      
-    case UICollectionView.elementKindSectionFooter:
-      let footerView: ListFooterView = collectionView.dequeReusableFooterView(forIndexPath: indexPath)
-      return footerView
-      
-    default:
-      return UICollectionReusableView()
-    }
-  }
-}
+extension BoardDetailCollectionViewCell: UICollectionViewDelegate {}
 
 
 // MARK: - Extension UICollectionView Drag Delegate
@@ -134,7 +105,7 @@ extension BoardDetailCollectionViewCell: UICollectionViewDragDelegate {
   
   // 1. 드래깅 시작
   func collectionView(_ collectionView: UICollectionView, itemsForBeginning session: UIDragSession, at indexPath: IndexPath) -> [UIDragItem] {
-    let card = viewModel.fetchCard(at: indexPath.row)
+    let card = viewModel.fetchCard(at: indexPath.item)
     let itemProvider = NSItemProvider(object: card)
     
     let dragItem = UIDragItem(itemProvider: itemProvider)
@@ -148,6 +119,12 @@ extension BoardDetailCollectionViewCell: UICollectionViewDragDelegate {
 // MARK: - Extension UICollectionView Drop Delegate
 
 extension BoardDetailCollectionViewCell: UICollectionViewDropDelegate {
+  
+  func collectionView(_ collectionView: UICollectionView, canHandle session: UIDropSession) -> Bool {
+    
+    
+    return drop
+  }
   
   // 2. 드래깅 중
   func collectionView(_ collectionView: UICollectionView, dropSessionDidUpdate session: UIDropSession, withDestinationIndexPath destinationIndexPath: IndexPath?) -> UICollectionViewDropProposal {
@@ -173,22 +150,22 @@ extension BoardDetailCollectionViewCell: UICollectionViewDropDelegate {
       let destination = coordinator.destinationIndexPath
             
       switch (source, destination) {
-      ///  ** 1. 같은 테이블뷰**
+      ///  ** 1. 같은 컬렉션뷰**
       case (.some(let sourceIndexPath), .some(let destinationIndexPath)):
         changeData(inSame: collectionView, about: card, by: sourceIndexPath, and: destinationIndexPath)
                 
-      /// **2. 다른 테이블뷰: cell 이 있는 테이블뷰에 삽입할 때(insert)**
+      /// **2. 다른 컬렉션뷰: cell 이 있는 테이블뷰에 삽입할 때(insert)**
       case (nil, .some(let destinationIndexPath)):
         let localContext = coordinator.session.localDragSession?.localContext
         
         insertData(with: localContext) {
-          viewModel.insert(card: card, at: destinationIndexPath.row)
+          viewModel.insert(card: card, at: destinationIndexPath.item)
           
-          let row = destinationIndexPath.row
-          collectionView.insertItems(at: [IndexPath(row: row, section: 0)])
+          let item = destinationIndexPath.item
+          collectionView.insertItems(at: [IndexPath(item: item, section: 0)])
         }
                 
-      /// **3. 다른 테이블뷰: cell 이 없는 컬렉션뷰에 삽입할 때(append)**
+      /// **3. 다른 컬렉션뷰: cell 이 없는 컬렉션뷰에 삽입할 때(append)**
       case (.some(_), nil):
         fallthrough
       case (nil, nil):
@@ -197,8 +174,8 @@ extension BoardDetailCollectionViewCell: UICollectionViewDropDelegate {
         insertData(with: localContext) {
           viewModel.append(card: card)
           
-          let row = viewModel.numberOfCards()-1
-          collectionView.insertItems(at: [IndexPath(row: row, section: 0)])
+          let item = viewModel.numberOfCards()-1
+          collectionView.insertItems(at: [IndexPath(item: item, section: 0)])
         }
       }
     }
@@ -212,8 +189,8 @@ extension BoardDetailCollectionViewCell: UICollectionViewDropDelegate {
   ) {
     let updatedIndexPaths = viewModel.makeUpdatedIndexPaths(by: sourceIndexPath, and: destinationIndexPath)
     
-    viewModel.removeCard(at: sourceIndexPath.row)
-    viewModel.insert(card: card, at: destinationIndexPath.row)
+    viewModel.removeCard(at: sourceIndexPath.item)
+    viewModel.insert(card: card, at: destinationIndexPath.item)
     
     collectionView.reloadItems(at: updatedIndexPaths)
   }
@@ -238,7 +215,22 @@ extension BoardDetailCollectionViewCell: UICollectionViewDropDelegate {
               UICollectionView
             ) else { return }
     
-    sourceViewModel.removeCard(at: sourceIndexPath.row)
+    sourceViewModel.removeCard(at: sourceIndexPath.item)
+    // sourceViewModel 로부터 카드 id 얻어온 다음 list, position 정보 서버로 전송
+    
     collectionView.reloadSections(IndexSet(integer: 0))
+  }
+}
+
+
+// MARK: - Extension objc
+
+extension BoardDetailCollectionViewCell {
+  
+  @objc func listWillDragged() {
+    drop = false
+  }
+  @objc func listDidDragged() {
+    drop = true
   }
 }

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/View/CollectionView/BoardDetailCollectionViewCell.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/View/CollectionView/BoardDetailCollectionViewCell.swift
@@ -24,7 +24,7 @@ final class BoardDetailCollectionViewCell: UICollectionViewCell, Reusable {
     
     return collectionView
   }()
-  private var drop = true
+  private var isDroppable: Bool = true
   
   // MARK: - Initializer
   
@@ -74,7 +74,6 @@ private extension BoardDetailCollectionViewCell {
   
   func configureCollectionView() {
     collectionView.delegate = self
-    
     collectionView.dragInteractionEnabled = true
     collectionView.dragDelegate = self
     collectionView.dropDelegate = self
@@ -96,7 +95,13 @@ private extension BoardDetailCollectionViewCell {
 
 // MARK: - Extension UICollectionView Delegate
 
-extension BoardDetailCollectionViewCell: UICollectionViewDelegate {}
+extension BoardDetailCollectionViewCell: UICollectionViewDelegate {
+  
+  func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+    // TODO: 카드 id 얻어서 카드 상세화면으로 넘어가는 로직 필요(viewmodel에게 물어보면 될듯함)
+    
+  }
+}
 
 
 // MARK: - Extension UICollectionView Drag Delegate
@@ -123,7 +128,7 @@ extension BoardDetailCollectionViewCell: UICollectionViewDropDelegate {
   func collectionView(_ collectionView: UICollectionView, canHandle session: UIDropSession) -> Bool {
     
     
-    return drop
+    return isDroppable
   }
   
   // 2. 드래깅 중
@@ -228,9 +233,9 @@ extension BoardDetailCollectionViewCell: UICollectionViewDropDelegate {
 extension BoardDetailCollectionViewCell {
   
   @objc func listWillDragged() {
-    drop = false
+    isDroppable = false
   }
   @objc func listDidDragged() {
-    drop = true
+    isDroppable = true
   }
 }

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/View/CollectionView/BoardDetailCollectionViewCell.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/View/CollectionView/BoardDetailCollectionViewCell.swift
@@ -112,6 +112,9 @@ extension BoardDetailCollectionViewCell: UICollectionViewDelegate {
     switch kind {
     case UICollectionView.elementKindSectionHeader:
       let headerView: ListHeaderView = collectionView.dequeReusableHeaderView(forIndexPath: indexPath)
+      
+      headerView.update(with: viewModel)
+      
       return headerView
       
     case UICollectionView.elementKindSectionFooter:

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/View/CollectionView/BoardDetailCollectionViewDataSource.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/View/CollectionView/BoardDetailCollectionViewDataSource.swift
@@ -1,0 +1,54 @@
+//
+//  BoardDetailCollectionViewDataSource.swift
+//  AreUDone
+//
+//  Created by a1111 on 2020/12/08.
+//
+
+import UIKit
+
+
+final class BoardDetailCollectionViewDataSource: NSObject, UICollectionViewDataSource {
+  
+  // MARK: - Property
+  
+  private let viewModel: BoardDetailViewModelProtocol
+
+  
+  // MARK: - Initializer
+  
+  init(viewModel: BoardDetailViewModelProtocol) {
+    self.viewModel = viewModel
+    
+    super.init()
+  }
+  
+  
+  // MARK: - Method
+  
+  func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    return viewModel.numberOfLists()
+  }
+  
+  func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+    let cell: BoardDetailCollectionViewCell = collectionView.dequeueReusableCell(forIndexPath: indexPath)
+    
+    viewModel.fetchListViewModel(at: indexPath.item) { viewModel in
+      let dataSource = ListCollectionViewDataSource(viewModel: viewModel)
+      cell.update(with: viewModel, dataSource: dataSource)
+    }
+  
+    return cell
+  }
+  
+  func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
+    let footerView: BoardDetailFooterView = collectionView.dequeReusableFooterView(forIndexPath: indexPath)
+    
+    footerView.addHandler = { [weak self] title in
+      self?.viewModel.createList(with: title)
+    }
+    return footerView
+  }
+}
+
+

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/View/CollectionView/BoardDetailCollectionViewDataSource.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/View/CollectionView/BoardDetailCollectionViewDataSource.swift
@@ -13,13 +13,14 @@ final class BoardDetailCollectionViewDataSource: NSObject, UICollectionViewDataS
   // MARK: - Property
   
   private let viewModel: BoardDetailViewModelProtocol
-
+  private var handler: ((Int) -> Void)?
+  
   
   // MARK: - Initializer
   
-  init(viewModel: BoardDetailViewModelProtocol) {
+  init(viewModel: BoardDetailViewModelProtocol, handler: ((Int) -> Void)? = nil) {
     self.viewModel = viewModel
-    
+    self.handler = handler
     super.init()
   }
   
@@ -33,6 +34,7 @@ final class BoardDetailCollectionViewDataSource: NSObject, UICollectionViewDataS
   func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
     let cell: BoardDetailCollectionViewCell = collectionView.dequeueReusableCell(forIndexPath: indexPath)
     
+    // TODO: 카드 id 가 있는 핸들러(카드상세화면), 리스트 id 가 있는 핸들러(카드 추가 화면)
     viewModel.fetchListViewModel(at: indexPath.item) { viewModel in
       let dataSource = ListCollectionViewDataSource(viewModel: viewModel)
       cell.update(with: viewModel, dataSource: dataSource)

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/View/CollectionView/BoardDetailFooterView.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/View/CollectionView/BoardDetailFooterView.swift
@@ -106,8 +106,8 @@ private extension BoardDetailFooterView {
 
 extension BoardDetailFooterView: AddOrCancelViewDelegate {
   
-  func addButtonTapped(text: String) {
-    addHandler?(text)
+  func addButtonTapped(listTitle: String) {
+    addHandler?(listTitle)
     cancelButtonTapped()
   }
   

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/View/CollectionView/ListCollectionView.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/View/CollectionView/ListCollectionView.swift
@@ -29,12 +29,35 @@ final class ListCollectionView: UICollectionView {
 private extension ListCollectionView {
   
   func configure() {
+    
+    configureView()
+    configureFlowLayout()
+  }
+  
+  func configureView() {
+    backgroundColor = .clear
+    showsVerticalScrollIndicator = false
+    
     register(ListCollectionViewCell.self)
     registerHeaderView(ListHeaderView.self)
     registerFooterView(ListFooterView.self)
-    
-    backgroundColor = .clear
-    showsVerticalScrollIndicator = false
   }
+  
+  func configureFlowLayout() {
+    let flowLayout = UICollectionViewFlowLayout()
+  
+    flowLayout.headerReferenceSize = CGSize(width: bounds.width, height: 45)
+    flowLayout.footerReferenceSize = CGSize(width: bounds.width, height: 45)
+    flowLayout.itemSize = CGSize(width: bounds.width - 40, height: 40)
+    
+    flowLayout.sectionInset = UIEdgeInsets.sameInset(inset: 10)
+   
+    flowLayout.sectionHeadersPinToVisibleBounds = true
+    flowLayout.sectionFootersPinToVisibleBounds = true
+    
+    collectionViewLayout = flowLayout
+  }
+  
+  
 }
 

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/View/CollectionView/ListCollectionViewCell.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/View/CollectionView/ListCollectionViewCell.swift
@@ -14,7 +14,9 @@ final class ListCollectionViewCell: UICollectionViewCell, Reusable {
   private lazy var titleLabel: UILabel = {
     let titleLabel = UILabel()
     titleLabel.translatesAutoresizingMaskIntoConstraints = false
-
+    
+    titleLabel.font = UIFont.nanumR(size: 18)
+    
     return titleLabel
   }()
   

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/View/CollectionView/ListCollectionViewDataSource.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/View/CollectionView/ListCollectionViewDataSource.swift
@@ -1,0 +1,58 @@
+//
+//  ListCollectionViewDataSource.swift
+//  AreUDone
+//
+//  Created by a1111 on 2020/12/08.
+//
+
+import UIKit
+
+
+final class ListCollectionViewDataSource: NSObject, UICollectionViewDataSource {
+  
+  // MARK: - Property
+  
+  private let viewModel: ListViewModelProtocol
+  
+  
+  // MARK: - Initializer
+  
+  init(viewModel: ListViewModelProtocol) {
+    self.viewModel = viewModel
+    
+    super.init()
+  }
+  
+  
+  // MARK: - Method
+  
+  func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    return viewModel.numberOfCards()
+  }
+  
+  func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+    let cell: ListCollectionViewCell = collectionView.dequeueReusableCell(forIndexPath: indexPath)
+    
+    cell.update(with: viewModel.fetchCard(at: indexPath.row))
+    
+    return cell
+  }
+  
+  func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
+    switch kind {
+    case UICollectionView.elementKindSectionHeader:
+      let headerView: ListHeaderView = collectionView.dequeReusableHeaderView(forIndexPath: indexPath)
+      
+      headerView.update(with: viewModel)
+      
+      return headerView
+      
+    case UICollectionView.elementKindSectionFooter:
+      let footerView: ListFooterView = collectionView.dequeReusableFooterView(forIndexPath: indexPath)
+      return footerView
+      
+    default:
+      return UICollectionReusableView()
+    }
+  }
+}

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/View/CollectionView/ListCollectionViewDataSource.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/View/CollectionView/ListCollectionViewDataSource.swift
@@ -19,7 +19,7 @@ final class ListCollectionViewDataSource: NSObject, UICollectionViewDataSource {
   
   init(viewModel: ListViewModelProtocol) {
     self.viewModel = viewModel
-    
+
     super.init()
   }
   
@@ -48,6 +48,8 @@ final class ListCollectionViewDataSource: NSObject, UICollectionViewDataSource {
       return headerView
       
     case UICollectionView.elementKindSectionFooter:
+      // TODO: 여기서 카드 추가화면 띄우는 로직 필요
+      // viewmodel.createCard(리스트id) 핸들러? footerview에게 넘겨주기
       let footerView: ListFooterView = collectionView.dequeReusableFooterView(forIndexPath: indexPath)
       return footerView
       

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/View/CollectionView/ListFooterView.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/View/CollectionView/ListFooterView.swift
@@ -16,6 +16,7 @@ final class ListFooterView: UICollectionReusableView, Reusable {
     titleLabel.translatesAutoresizingMaskIntoConstraints = false
 
     titleLabel.text = "카드 추가"
+    titleLabel.font = UIFont.nanumB(size: 18)
     
     return titleLabel
   }()

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/View/CollectionView/ListFooterView.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/View/CollectionView/ListFooterView.swift
@@ -10,7 +10,7 @@ import UIKit
 final class ListFooterView: UICollectionReusableView, Reusable {
   
   // MARK: - Property
-  
+    
   private lazy var titleLabel: UILabel = {
     let titleLabel = UILabel()
     titleLabel.translatesAutoresizingMaskIntoConstraints = false
@@ -26,10 +26,7 @@ final class ListFooterView: UICollectionReusableView, Reusable {
 
     view.layer.cornerRadius = 10
     
-    view.layer.shadowColor = UIColor.black.cgColor
-    view.layer.shadowOffset = .zero
-    view.layer.shadowRadius = 1
-    view.layer.shadowOpacity = 1
+    view.addShadow(offset: .zero, radius: 1, opacity: 1)
     
     view.backgroundColor = .white
     
@@ -71,6 +68,9 @@ private extension ListFooterView {
   }
   
   func configureBaseView() {
+    let gestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(baseViewTapped))
+    baseView.addGestureRecognizer(gestureRecognizer)
+    
     NSLayoutConstraint.activate([
       baseView.topAnchor.constraint(equalTo: topAnchor, constant: 2),
       baseView.centerXAnchor.constraint(equalTo: centerXAnchor),
@@ -87,4 +87,13 @@ private extension ListFooterView {
   }
 }
 
+
+// MARK: - Extension objc
+
+extension ListFooterView {
+  
+  @objc func baseViewTapped() {
+    
+  }
+}
 

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/View/CollectionView/ListHeaderView.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/View/CollectionView/ListHeaderView.swift
@@ -84,11 +84,14 @@ private extension ListHeaderView {
 
 extension ListHeaderView: UITextFieldDelegate {
   
-  func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+  func textFieldDidEndEditing(_ textField: UITextField) {
     if let title = textField.text {
       viewModel.updateListTitle(to: title)
     }
-    
+    textField.resignFirstResponder()
+  }
+
+  func textFieldShouldReturn(_ textField: UITextField) -> Bool {
     textField.resignFirstResponder()
     return false
   }

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/View/CollectionView/ListHeaderView.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/View/CollectionView/ListHeaderView.swift
@@ -11,11 +11,17 @@ final class ListHeaderView: UICollectionReusableView, Reusable {
   
   // MARK: - Property
   
-  private lazy var titleLabel: UILabel = {
-    let titleLabel = UILabel()
-    titleLabel.translatesAutoresizingMaskIntoConstraints = false
+  private var viewModel: ListViewModelProtocol!
+  
+  private lazy var titleTextField: UITextField = {
+    let textField = UITextField()
+    textField.translatesAutoresizingMaskIntoConstraints = false
+    
+    textField.returnKeyType = .done
+    textField.delegate = self
+    textField.font = UIFont.nanumB(size: 18)
 
-    return titleLabel
+    return textField
   }()
   
   
@@ -24,6 +30,7 @@ final class ListHeaderView: UICollectionReusableView, Reusable {
   required init?(coder: NSCoder) {
     super.init(coder: coder)
     
+    bindUI()
     configure()
   }
   
@@ -31,6 +38,16 @@ final class ListHeaderView: UICollectionReusableView, Reusable {
     super.init(frame: frame)
     
     configure()
+  }
+  
+  
+  // MARK: - Method
+  
+  func update(with viewModel: ListViewModelProtocol) {
+    self.viewModel = viewModel
+    bindUI()
+
+    titleTextField.text = viewModel.fetchListTitle()
   }
 }
 
@@ -40,10 +57,10 @@ final class ListHeaderView: UICollectionReusableView, Reusable {
 private extension ListHeaderView {
 
   func configure() {
-    addSubview(titleLabel)
+    addSubview(titleTextField)
     
     configureView()
-    configureTitle()
+    configureTitleTextField()
   }
   
   func configureView() {
@@ -55,15 +72,36 @@ private extension ListHeaderView {
     layer.shadowRadius = 0.4
     layer.shadowOpacity = 0.3
   }
-
-  func configureTitle() {
-    // TODO: 수정 예정
-    titleLabel.text = "TODO"
-    
+  
+  func configureTitleTextField() {
     NSLayoutConstraint.activate([
-      titleLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
-      titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 30)
+      titleTextField.centerYAnchor.constraint(equalTo: centerYAnchor),
+      titleTextField.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 15),
+      titleTextField.trailingAnchor.constraint(equalTo: trailingAnchor, constant: 15)
     ])
+  }
+}
+
+extension ListHeaderView: UITextFieldDelegate {
+  
+  func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+    if let title = textField.text {
+      viewModel.updateListTitle(to: title)
+    }
+    
+    textField.resignFirstResponder()
+    return false
+  }
+}
+
+private extension ListHeaderView {
+  
+  func bindUI() {
+    viewModel.bindingUpdateListTitle { [weak self] title in
+      DispatchQueue.main.async {
+        self?.titleTextField.text = title
+      }
+    }
   }
 }
 

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/View/Controller/BoardDetailViewController.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/View/Controller/BoardDetailViewController.swift
@@ -198,12 +198,10 @@ extension BoardDetailViewController: UICollectionViewDataSource {
   func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
     let cell: BoardDetailCollectionViewCell = collectionView.dequeueReusableCell(forIndexPath: indexPath)
     
-    guard let list = viewModel.fetchList(at: indexPath.item)
-    else { return UICollectionViewCell() }
-    
-    let viewModel = ListViewModel(list: list)
-    
-    cell.update(with: viewModel)
+    viewModel.fetchList(at: indexPath.item) { viewModel in
+      cell.update(with: viewModel)
+    }
+  
     return cell
   }
 }

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/View/Controller/BoardDetailViewController.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/View/Controller/BoardDetailViewController.swift
@@ -69,7 +69,7 @@ final class BoardDetailViewController: UIViewController {
   
   override func viewDidLoad() {
     super.viewDidLoad()
-   
+
     bindUI()
     configure()
     
@@ -105,6 +105,7 @@ private extension BoardDetailViewController {
   }
   
   func configureNavigationBar() {
+    navigationController?.isNavigationBarHidden = false
     navigationItem.largeTitleDisplayMode = .never
     guard let navigationBar = navigationController?.navigationBar else { return }
     

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/View/Controller/BoardDetailViewController.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/View/Controller/BoardDetailViewController.swift
@@ -297,7 +297,7 @@ extension BoardDetailViewController: UICollectionViewDropDelegate {
     and destinationIndexPath: IndexPath
   ) {
     
-    // TODO: viewModel 로 바인딩하기
+    // TODO: API 연동해보고 success 후 로컬 변경 or 로컬 변경 우선 선택
     let updatedIndexPaths = viewModel.makeUpdatedIndexPaths(by: sourceIndexPath, and: destinationIndexPath)
     
     viewModel.remove(at: sourceIndexPath.row)

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/View/Controller/BoardDetailViewController.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/View/Controller/BoardDetailViewController.swift
@@ -244,9 +244,7 @@ extension BoardDetailViewController: UICollectionViewDragDelegate {
     let itemProvider = NSItemProvider(object: list)
     
     let dragItem = UIDragItem(itemProvider: itemProvider)
-    
-    session.localContext = (viewModel, indexPath, collectionView)
-    
+        
     return [dragItem]
   }
   
@@ -285,7 +283,9 @@ extension BoardDetailViewController: UICollectionViewDropDelegate {
       guard let source = coordinator.items.first?.sourceIndexPath,
             let destination = coordinator.destinationIndexPath
       else { return }
-      
+     
+      viewModel.updatePosition(of: source.item, to: destination.item)
+
       changeData(inSame: collectionView, about: list, by: source, and: destination)
     }
   }
@@ -296,14 +296,14 @@ extension BoardDetailViewController: UICollectionViewDropDelegate {
     by sourceIndexPath: IndexPath,
     and destinationIndexPath: IndexPath
   ) {
+    
+    // TODO: viewModel 로 바인딩하기
     let updatedIndexPaths = viewModel.makeUpdatedIndexPaths(by: sourceIndexPath, and: destinationIndexPath)
     
     viewModel.remove(at: sourceIndexPath.row)
     viewModel.insert(list: list, at: destinationIndexPath.row)
     
     collectionView.reloadItems(at: updatedIndexPaths)
-    
-    
   }
 }
 

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/View/Controller/BoardDetailViewController.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/View/Controller/BoardDetailViewController.swift
@@ -14,7 +14,10 @@ final class BoardDetailViewController: UIViewController {
   
   private let viewModel: BoardDetailViewModelProtocol
   weak var coordinator: BoardDetailCoordinator?
-  private lazy var dataSource = BoardDetailCollectionViewDataSource(viewModel: viewModel)
+  private lazy var dataSource = BoardDetailCollectionViewDataSource(viewModel: viewModel) { [weak self] cardId in
+    
+    // TODO: 카드 추가 화면으로 가는 로직
+  }
   
   private lazy var titleTextField: UITextField = {
     let textField = UITextField()

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/ViewModel/BoardDetailViewModel.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/ViewModel/BoardDetailViewModel.swift
@@ -10,12 +10,15 @@ import Foundation
 protocol BoardDetailViewModelProtocol {
   
   func bindingUpdateBoardDetailCollectionView(handler: @escaping () -> Void)
-  
-  func updateBoardDetailCollectionView()
-  
+  func bindingUpdateBackgroundColor(handler: @escaping (String) -> Void)
+  func bindingUpdateBoardTitle(handler: @escaping (String) -> Void)
+    
   func numberOfLists() -> Int
   func fetchList(at index: Int) -> List?
   func insertList(list: List)
+  
+  func updateBoardDetailCollectionView()
+  func updateBoardTitle(to title: String)
 }
 
 final class BoardDetailViewModel: BoardDetailViewModelProtocol {
@@ -26,13 +29,25 @@ final class BoardDetailViewModel: BoardDetailViewModelProtocol {
   private let boardId: Int
   
   private var updateBoardDetailCollectionViewHandler: (() -> Void)?
+  private var updateBackgroundColorHandler: ((String) -> Void)?
+  private var updateBoardTitleHandler: ((String) -> Void)?
   
   private var boardDetail: BoardDetail? {
     didSet {
       updateBoardDetailCollectionViewHandler?()
     }
   }
-
+  private var backgroundColor: String = "" {
+    didSet {
+      updateBackgroundColorHandler?(backgroundColor)
+    }
+  }
+  private var boardTitle: String = "" {
+    didSet {
+      updateBoardTitleHandler?(boardTitle)
+    }
+  }
+  
   // MARK: - Initializer
   
   init(boardService: BoardServiceProtocol, boardId: Int) {
@@ -60,6 +75,22 @@ final class BoardDetailViewModel: BoardDetailViewModelProtocol {
       switch result {
       case .success(let boardDetail):
         self.boardDetail = boardDetail
+        
+        self.backgroundColor = boardDetail.color
+        self.boardTitle = boardDetail.title
+        
+      case .failure(let error):
+        print(error)
+      }
+    }
+  }
+  
+  func updateBoardTitle(to title: String) {
+    boardService.updateBoard(withBoardId: boardId, title: boardTitle) { result in
+      switch result {
+      case .success(()):
+        self.boardTitle = title
+        
       case .failure(let error):
         print(error)
       }
@@ -74,5 +105,13 @@ extension BoardDetailViewModel {
   
   func bindingUpdateBoardDetailCollectionView(handler: @escaping () -> Void) {
     updateBoardDetailCollectionViewHandler = handler
+  }
+  
+  func bindingUpdateBackgroundColor(handler: @escaping (String) -> Void) {
+    updateBackgroundColorHandler = handler
+  }
+  
+  func bindingUpdateBoardTitle(handler: @escaping (String) -> Void) {
+    updateBoardTitleHandler = handler
   }
 }

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/ViewModel/BoardDetailViewModel.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/ViewModel/BoardDetailViewModel.swift
@@ -23,6 +23,7 @@ protocol BoardDetailViewModelProtocol {
 
   func updateBoardDetailCollectionView()
   func updateBoardTitle(to title: String)
+  func updatePosition(of sourceIndex: Int, to destinationIndex: Int)
   
   func createList(with title: String)
   
@@ -82,8 +83,6 @@ final class BoardDetailViewModel: BoardDetailViewModelProtocol {
     boardDetail?.lists.insert(list, at: index)
   }
   
-  
-  
   func fetchListViewModel(at index: Int, handler: ((ListViewModelProtocol) -> Void)) {
     guard let list = boardDetail?.lists[index] else { return }
     
@@ -127,6 +126,34 @@ final class BoardDetailViewModel: BoardDetailViewModelProtocol {
         print(error)
       }
     }
+  }
+  
+  func updatePosition(of sourceIndex: Int, to destinationIndex: Int) {
+    guard let lists = boardDetail?.lists else { return }
+    
+    // TODO: API 연동 후 수정 예정
+
+    let listId = lists[sourceIndex].id
+    
+    var position: Double
+    if lists.count != (destinationIndex+1) {
+      position = (lists[destinationIndex-1].position + lists[destinationIndex].position) / 2
+    } else {
+      // 맨 마지막에 넣는 경우 (다음에 올 수 있는 position 값 구함)
+      position = (lists[destinationIndex].position + floor((lists[destinationIndex].position) + 1)) / 2
+    }
+    
+    print(position)
+    
+//    listService.updateList(withListId: listId, position: position, title: nil) { result in
+//      switch result {
+//      case .success(()):
+//        break
+//
+//      case .failure(let error):
+//        print(error)
+//      }
+//    }
   }
   
   func createList(with title: String) {

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/ViewModel/BoardDetailViewModel.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/ViewModel/BoardDetailViewModel.swift
@@ -88,6 +88,7 @@ final class BoardDetailViewModel: BoardDetailViewModelProtocol {
     
     let viewModel = ListViewModel(
       listService: listService,
+      cardService: cardService,
       list: list
     )
     handler(viewModel)
@@ -142,18 +143,16 @@ final class BoardDetailViewModel: BoardDetailViewModelProtocol {
       // 맨 마지막에 넣는 경우 (다음에 올 수 있는 position 값 구함)
       position = (lists[destinationIndex].position + floor((lists[destinationIndex].position) + 1)) / 2
     }
-    
-    print(position)
-    
-//    listService.updateList(withListId: listId, position: position, title: nil) { result in
-//      switch result {
-//      case .success(()):
-//        break
-//
-//      case .failure(let error):
-//        print(error)
-//      }
-//    }
+        
+    listService.updateList(withListId: listId, position: position, title: nil) { result in
+      switch result {
+      case .success(()):
+        break
+
+      case .failure(let error):
+        print(error)
+      }
+    }
   }
   
   func createList(with title: String) {
@@ -161,6 +160,7 @@ final class BoardDetailViewModel: BoardDetailViewModelProtocol {
       switch result {
       case .success(()):
         self.updateBoardDetailCollectionView()
+        
       case .failure(let error):
         print(error)
       }

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/ViewModel/ListViewModel.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/ViewModel/ListViewModel.swift
@@ -28,6 +28,7 @@ final class ListViewModel: ListViewModelProtocol {
   // MARK: - Property
   
   private let listService: ListServiceProtocol
+  private let cardService: CardServiceProtocol
   
   private var updateListTitleHandler: ((String) -> Void)?
   
@@ -38,9 +39,11 @@ final class ListViewModel: ListViewModelProtocol {
   
   init(
     listService: ListServiceProtocol,
+    cardService: CardServiceProtocol,
     list: List
   ) {
     self.listService = listService
+    self.cardService = cardService
     self.list = list
     
     self.listTitle = list.title

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/ViewModel/ListViewModel.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/ViewModel/ListViewModel.swift
@@ -32,12 +32,14 @@ final class ListViewModel: ListViewModelProtocol {
   private var updateListTitleHandler: ((String) -> Void)?
   
   private let list: List
-
   private var listTitle: String = ""
   
   // MARK: - Initializer
   
-  init(listService: ListServiceProtocol, list: List) {
+  init(
+    listService: ListServiceProtocol,
+    list: List
+  ) {
     self.listService = listService
     self.list = list
     

--- a/iOS/AreUDone/AreUDone/BoardListScene/BoardListCoordinator.swift
+++ b/iOS/AreUDone/AreUDone/BoardListScene/BoardListCoordinator.swift
@@ -33,14 +33,16 @@ final class BoardListCoordinator: NavigationCoordinator {
   func start() -> UIViewController {
     
     guard let boardListViewController = storyboard.instantiateViewController(
-            identifier: BoardListViewController.identifier, creator: { coder in
+            identifier: BoardListViewController.identifier, creator: { [weak self] coder in
+              guard let self = self else { return UIViewController() }
+              
               let boardService = BoardService(router: MockRouter(jsonFactory: BoardListTrueJsonFactory()))
-      let viewModel = BoardListViewModel(boardService: boardService)
-      return BoardListViewController(coder: coder, viewModel: viewModel, sectionFactory: SectionContentsFactory())
-    }) as? BoardListViewController else { return UIViewController() }
-
+              let viewModel = BoardListViewModel(boardService: boardService)
+              return BoardListViewController(coder: coder, viewModel: viewModel, sectionFactory: SectionContentsFactory())
+            }) as? BoardListViewController else { return UIViewController() }
+    
     boardListViewController.coordinator = self
-
+    
     return boardListViewController
   }
 }

--- a/iOS/AreUDone/AreUDone/BoardListScene/BoardListCoordinator.swift
+++ b/iOS/AreUDone/AreUDone/BoardListScene/BoardListCoordinator.swift
@@ -36,7 +36,7 @@ final class BoardListCoordinator: NavigationCoordinator {
             identifier: BoardListViewController.identifier, creator: { [weak self] coder in
               guard let self = self else { return UIViewController() }
               
-              let boardService = BoardService(router: MockRouter(jsonFactory: BoardListTrueJsonFactory()))
+              let boardService = BoardService(router: self.router)
               let viewModel = BoardListViewModel(boardService: boardService)
               return BoardListViewController(coder: coder, viewModel: viewModel, sectionFactory: SectionContentsFactory())
             }) as? BoardListViewController else { return UIViewController() }
@@ -53,7 +53,7 @@ final class BoardListCoordinator: NavigationCoordinator {
 extension BoardListCoordinator {
   
   func pushToBoardDetail(boardId: Int) {
-    boardDetailCoordinator = BoardDetailCoordinator(boardId: boardId)
+    boardDetailCoordinator = BoardDetailCoordinator(router: router, boardId: boardId)
     boardDetailCoordinator.navigationController = navigationController
     
     let viewController = boardDetailCoordinator.start()
@@ -62,7 +62,7 @@ extension BoardListCoordinator {
     navigationController?.pushViewController(viewController, animated: true)
   }
   
-  func pushToBoardAdd() {
+  func presentBoardAdd() {
     boardAddCoordinator = BoardAddCoordinator(router: router)
     boardAddCoordinator.navigationController = navigationController
     
@@ -70,6 +70,7 @@ extension BoardListCoordinator {
     let subNavigationController = UINavigationController()
     subNavigationController.pushViewController(viewController, animated: true)
     
+    subNavigationController.modalPresentationStyle = .fullScreen
     navigationController?.present(subNavigationController, animated: true)
   }
 }

--- a/iOS/AreUDone/AreUDone/BoardListScene/View/CollectionView/BoardListCollectionViewCell.swift
+++ b/iOS/AreUDone/AreUDone/BoardListScene/View/CollectionView/BoardListCollectionViewCell.swift
@@ -39,7 +39,7 @@ final class BoardListCollectionViewCell: UICollectionViewCell, Reusable {
   
   func update(with board: Board) {
     titleLabel.text = board.title
-    backgroundColor = board.color.hexStringToUIColor().withAlphaComponent(0.5)
+    backgroundColor = board.color.toUIColor().withAlphaComponent(0.5)
   }
 }
 

--- a/iOS/AreUDone/AreUDone/BoardListScene/View/Controller/BoardListViewController.swift
+++ b/iOS/AreUDone/AreUDone/BoardListScene/View/Controller/BoardListViewController.swift
@@ -108,11 +108,6 @@ final class BoardListViewController: UIViewController {
     
     viewModel.fetchMyBoard()
   }
-  
-  override func viewWillDisappear(_ animated: Bool) {
-    super.viewWillDisappear(animated)
-    navigationController?.isNavigationBarHidden = false
-  }
 }
 
 
@@ -183,8 +178,10 @@ private extension BoardListViewController {
 extension BoardListViewController: UICollectionViewDelegate {
   
   func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-    // TODO: boardId 받아오는 메소드 작성
-    coordinator?.pushToBoardDetail(boardId: 1)
+    
+    viewModel.fetchBoardId(at: indexPath) { boardId in
+      coordinator?.pushToBoardDetail(boardId: boardId)
+    }
   }
 }
 
@@ -219,6 +216,6 @@ extension BoardListViewController: CustomSegmentedControlDelegate {
 private extension BoardListViewController {
   
   @objc func addBoardButtonTapped() {
-    coordinator?.pushToBoardAdd()
+    coordinator?.presentBoardAdd()
   }
 }

--- a/iOS/AreUDone/AreUDone/BoardListScene/View/Controller/BoardListViewController.swift
+++ b/iOS/AreUDone/AreUDone/BoardListScene/View/Controller/BoardListViewController.swift
@@ -100,12 +100,13 @@ final class BoardListViewController: UIViewController {
     
     bindUI()
     configure()
-    viewModel.fetchMyBoard()
   }
   
   override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
     navigationController?.isNavigationBarHidden = true
+    
+    viewModel.fetchMyBoard()
   }
   
   override func viewWillDisappear(_ animated: Bool) {

--- a/iOS/AreUDone/AreUDone/BoardListScene/View/Controller/BoardListViewController.swift
+++ b/iOS/AreUDone/AreUDone/BoardListScene/View/Controller/BoardListViewController.swift
@@ -184,7 +184,7 @@ extension BoardListViewController: UICollectionViewDelegate {
   
   func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
     // TODO: boardId 받아오는 메소드 작성
-    coordinator?.pushToBoardDetail(boardId: 0)
+    coordinator?.pushToBoardDetail(boardId: 1)
   }
 }
 

--- a/iOS/AreUDone/AreUDone/BoardListScene/ViewModel/BoardListViewModel.swift
+++ b/iOS/AreUDone/AreUDone/BoardListScene/ViewModel/BoardListViewModel.swift
@@ -12,6 +12,7 @@ protocol BoardListViewModelProtocol {
   func bindingInitializeBoardListCollectionView(handler: @escaping ([Board]) -> Void)
   func bindingUpdateBoardListCollectionView(handler: @escaping ([Board]) -> Void)
   
+  func fetchBoardId(at indexPath: IndexPath, handler: (Int) -> Void)
   func fetchMyBoard()
   func fetchInvitedBoard()
 }
@@ -25,6 +26,8 @@ final class BoardListViewModel: BoardListViewModelProtocol {
   private var initializeBoardListCollectionViewHandler: (([Board]) -> Void)?
   private var updateBoardListCollectionViewHandler: (([Board]) -> Void)?
   
+  private var boards: [[Board]] = Array(repeating: [], count: 2)
+
   
   // MARK: - Initializer
   
@@ -35,10 +38,18 @@ final class BoardListViewModel: BoardListViewModelProtocol {
   
   // MARK: - Method
   
+  func fetchBoardId(at indexPath: IndexPath, handler: (Int) -> Void) {
+    let board = boards[indexPath.section][indexPath.item]
+    handler(board.id)
+  }
+  
   func fetchMyBoard() {
     boardService.fetchAllBoards() { result in
       switch result {
       case .success(let boards):
+        self.boards[0] = boards.myBoards
+        self.boards[1] = boards.invitedBoards
+        
         self.updateBoardListCollectionViewHandler?(boards.myBoards)
       case .failure(let error):
         print(error)
@@ -50,6 +61,9 @@ final class BoardListViewModel: BoardListViewModelProtocol {
     boardService.fetchAllBoards() { result in
       switch result {
       case .success(let boards):
+        self.boards[0] = boards.myBoards
+        self.boards[1] = boards.invitedBoards
+        
         self.updateBoardListCollectionViewHandler?(boards.invitedBoards)
       case .failure(let error):
         print(error)

--- a/iOS/AreUDone/AreUDone/CalendarScene/CalendarCoordinator.swift
+++ b/iOS/AreUDone/AreUDone/CalendarScene/CalendarCoordinator.swift
@@ -66,8 +66,7 @@ extension CalendarCoordinator {
   }
   
   func showCardDetail(for id: Int) {
-    let router = Router()
-    cardDetailCoordinator = CardDetailCoordinator(id: id, router: router)
+    cardDetailCoordinator = CardDetailCoordinator(id: id, router: self.router)
     cardDetailCoordinator.navigationController = navigationController
     
     let cardDetailViewController = cardDetailCoordinator.start()

--- a/iOS/AreUDone/AreUDone/Common/Extension/NotificationName+.swift
+++ b/iOS/AreUDone/AreUDone/Common/Extension/NotificationName+.swift
@@ -1,0 +1,8 @@
+//
+//  NotificationName.swift
+//  AreUDone
+//
+//  Created by a1111 on 2020/12/09.
+//
+
+import Foundation

--- a/iOS/AreUDone/AreUDone/Common/Extension/NotificationName+.swift
+++ b/iOS/AreUDone/AreUDone/Common/Extension/NotificationName+.swift
@@ -6,3 +6,9 @@
 //
 
 import Foundation
+
+extension Notification.Name {
+  
+  static let listWillDragged = Notification.Name("ListWillDragged")
+  static let listDidDragged = Notification.Name("ListDidDragged")
+}

--- a/iOS/AreUDone/AreUDone/Common/Extension/String+.swift
+++ b/iOS/AreUDone/AreUDone/Common/Extension/String+.swift
@@ -22,7 +22,7 @@ extension String {
     return dateFormatter.date(from: self) ?? Date()
   }
   
-  func hexStringToUIColor() -> UIColor {
+  func toUIColor() -> UIColor {
       var rgbValue: UInt64 = 0
       let droppedString = self.dropFirst()
 

--- a/iOS/AreUDone/AreUDone/Common/Mock/BoardDetailJsonFactory.swift
+++ b/iOS/AreUDone/AreUDone/Common/Mock/BoardDetailJsonFactory.swift
@@ -22,7 +22,7 @@ struct BoardDetailTrueJsonFactory: JsonFactory {
               "profileImageUrl": "https://d2u3dcdbebyaiu.cloudfront.net/uploads/atch_img/436/8142f53e51d2ec31bc0fa4bec241a919_crop.jpeg"
           },
           "title": "보드제목",
-          "color": "#525252",
+          "color": "#b1cf99",
           "invitedUsers": [
               {
                   "id": 1,

--- a/iOS/AreUDone/AreUDone/Common/Mock/BoardDetailJsonFactory.swift
+++ b/iOS/AreUDone/AreUDone/Common/Mock/BoardDetailJsonFactory.swift
@@ -15,9 +15,9 @@ struct BoardDetailTrueJsonFactory: JsonFactory {
     case BoardEndPoint.fetchBoardDetail:
       return """
       {
-          "id": 0,
+          "id": 1,
           "creator": {
-              "id": 0,
+              "id": 2,
               "name": "심영민",
               "profileImageUrl": "https://d2u3dcdbebyaiu.cloudfront.net/uploads/atch_img/436/8142f53e51d2ec31bc0fa4bec241a919_crop.jpeg"
           },
@@ -71,9 +71,37 @@ struct BoardDetailTrueJsonFactory: JsonFactory {
                   ]
               },
               {
-                  "id": 1,
-                  "title": "리스트 제목2",
+                  "id": 2,
+                  "title": "리스트 제목",
                   "position": 1,
+                  "cards": [
+                      {
+                          "id": 0,
+                          "title": "카드 제목",
+                          "position": 0,
+                          "commentCount": 5,
+                          "dueDate": "2020-12-02"
+                      }
+                  ]
+              },
+              {
+                  "id": 3,
+                  "title": "리스트 제목",
+                  "position": 2,
+                  "cards": [
+                      {
+                          "id": 0,
+                          "title": "카드 제목",
+                          "position": 0,
+                          "commentCount": 5,
+                          "dueDate": "2020-12-02"
+                      }
+                  ]
+              },
+              {
+                  "id": 4,
+                  "title": "리스트 제목2",
+                  "position": 3,
                   "cards": [
                       {
                           "id": 0,
@@ -202,6 +230,7 @@ struct BoardDetailTrueJsonFactory: JsonFactory {
                           "dueDate": "2020-12-02"
                       }
                   ]
+
               }
           ]
       }

--- a/iOS/AreUDone/AreUDone/Common/Model/Board.swift
+++ b/iOS/AreUDone/AreUDone/Common/Model/Board.swift
@@ -19,10 +19,11 @@ struct Board: Codable {
 
 extension Board: Hashable {
   static func == (lhs: Board, rhs: Board) -> Bool {
-    return lhs.id == rhs.id
+    return lhs.id == rhs.id && lhs.title == rhs.title
   }
   
   func hash(into hasher: inout Hasher) {
     hasher.combine(id)
+    hasher.combine(title)
   }
 }

--- a/iOS/AreUDone/AreUDone/Common/Model/BoardDetail.swift
+++ b/iOS/AreUDone/AreUDone/Common/Model/BoardDetail.swift
@@ -14,14 +14,3 @@ struct BoardDetail: Codable {
   let invitedUsers: [User]
   var lists: [List]
 }
-
-// MARK: - Creator
-struct Creator: Codable {
-  let id: Int
-  let name, profileImageUrl: String
-}
-
-struct InvitedUser: Codable {
-  let id: Int
-  let name, profileImageUrl: String
-}

--- a/iOS/AreUDone/AreUDone/Common/Model/BoardDetail.swift
+++ b/iOS/AreUDone/AreUDone/Common/Model/BoardDetail.swift
@@ -9,9 +9,9 @@ import Foundation
 
 struct BoardDetail: Codable {
   let id: Int
-  let creator: Creator
+  let creator: User
   let title, color: String
-  let invitedUsers: [InvitedUser]
+  let invitedUsers: [User]
   var lists: [List]
 }
 

--- a/iOS/AreUDone/AreUDone/Common/Model/List.swift
+++ b/iOS/AreUDone/AreUDone/Common/Model/List.swift
@@ -16,10 +16,10 @@ import MobileCoreServices
 class List: NSObject, Codable {
   let id: Int
   let title: String
-  let position: Int
+  let position: Double
   var cards: [Card]
   
-  init(id: Int, title: String, position: Int, cards: [Card]) {
+  init(id: Int, title: String, position: Double, cards: [Card]) {
     self.id = id
     self.title = title
     self.position = position

--- a/iOS/AreUDone/AreUDone/Common/Model/List.swift
+++ b/iOS/AreUDone/AreUDone/Common/Model/List.swift
@@ -7,12 +7,13 @@
 
 import Foundation
 import MobileCoreServices
-//
+
+// TODO: API 연동 확인 후 삭제 예정
 //struct Lists: Codable {
 //  let lists: [List]
 //}
 
-class List: Codable {
+class List: NSObject, Codable {
   let id: Int
   let title: String
   let position: Int
@@ -26,13 +27,43 @@ class List: Codable {
   }
 }
 
-extension List: Hashable {
-  
-  static func == (lhs: List, rhs: List) -> Bool {
-    return lhs.id == rhs.id
+extension List: NSItemProviderWriting {
+  static var writableTypeIdentifiersForItemProvider: [String] {
+    
+    return [kUTTypeData as String]
   }
   
-  func hash(into hasher: inout Hasher) {
-    hasher.combine(id)
+  func loadData(withTypeIdentifier typeIdentifier: String, forItemProviderCompletionHandler completionHandler: @escaping (Data?, Error?) -> Swift.Void) -> Progress? {
+    
+    do {
+      let encoder = JSONEncoder()
+      encoder.outputFormatting = .prettyPrinted
+      let data = try encoder.encode(self)
+      
+      completionHandler(data, nil)
+      print("성공")
+    } catch {
+      print("에러")
+      completionHandler(nil, error)
+    }
+    
+    return nil
   }
 }
+
+extension List: NSItemProviderReading {
+  static var readableTypeIdentifiersForItemProvider: [String] {
+    return [kUTTypeData as String]
+  }
+  
+  static func object(withItemProviderData data: Data, typeIdentifier: String) throws -> Self {
+    let decoder = JSONDecoder()
+    do {
+      let myJSON = try decoder.decode(List.self, from: data)
+      return myJSON as! Self
+    } catch {
+      fatalError("Err")
+    }
+  }
+}
+

--- a/iOS/AreUDone/AreUDone/Common/Model/User.swift
+++ b/iOS/AreUDone/AreUDone/Common/Model/User.swift
@@ -9,6 +9,7 @@ import Foundation
 
 struct User: Codable {
   
+  let id: Int
   let name: String
   let profileImageUrl: String
 }

--- a/iOS/AreUDone/AreUDone/Service/BoardService/BoardEndPoint.swift
+++ b/iOS/AreUDone/AreUDone/Service/BoardService/BoardEndPoint.swift
@@ -61,8 +61,11 @@ extension BoardEndPoint: EndPointable {
     case .fetchAllBoards, .fetchBoardDetail:
       return .get
       
-    case .createBoard, .updateBoard, .inviteUserToBoard:
+    case .createBoard, .inviteUserToBoard:
       return .post
+      
+    case .updateBoard:
+      return .put
       
     case .deleteBoard, .exitBoard:
       return .delete

--- a/iOS/AreUDone/AreUDone/Service/BoardService/BoardEndPoint.swift
+++ b/iOS/AreUDone/AreUDone/Service/BoardService/BoardEndPoint.swift
@@ -75,7 +75,7 @@ extension BoardEndPoint: EndPointable {
     
     return [
       "Authorization": "\(accessToken)",
-      "Content-Type": "application/json",
+      "Content-Type": "application/x-www-form-urlencoded",
       "Accept": "application/json"
     ]
   }

--- a/iOS/AreUDone/AreUDone/Service/BoardService/BoardService.swift
+++ b/iOS/AreUDone/AreUDone/Service/BoardService/BoardService.swift
@@ -12,7 +12,7 @@ protocol BoardServiceProtocol: class {
   
   func fetchAllBoards(completionHandler: @escaping (Result<Boards, APIError>) -> Void)
   func createBoard(withTitle title: String, color: String, completionHandler: @escaping (Result<Void, APIError>) -> Void)
-  func updateBoard(with boardId: Int, title: String, completionHandler: @escaping (Result<Boards, APIError>) -> Void)
+  func updateBoard(withBoardId boardId: Int, title: String, completionHandler: @escaping (Result<Void, APIError>) -> Void)
   func deleteBoard(with boardId: Int, completionHandler: @escaping (Result<Boards, APIError>) -> Void)
   
   func fetchBoardDetail(with boardId: Int, completionHandler: @escaping (Result<BoardDetail, APIError>) -> Void)
@@ -47,7 +47,7 @@ final class BoardService: BoardServiceProtocol {
     }
   }
   
-  func updateBoard(with boardId: Int, title: String, completionHandler: @escaping (Result<Boards, APIError>) -> Void) {
+  func updateBoard(withBoardId boardId: Int, title: String, completionHandler: @escaping (Result<Void, APIError>) -> Void) {
     router.request(route: BoardEndPoint.updateBoard(boardId: boardId, title: title)) { result in
       completionHandler(result)
     }

--- a/iOS/AreUDone/AreUDone/Service/ListService/ListEndPoint.swift
+++ b/iOS/AreUDone/AreUDone/Service/ListService/ListEndPoint.swift
@@ -1,0 +1,89 @@
+//
+//  ListEndPoint.swift
+//  AreUDone
+//
+//  Created by a1111 on 2020/12/08.
+//
+
+import Foundation
+import NetworkFramework
+import KeychainFramework
+
+enum ListEndPoint {
+  
+  case createList(boardId: Int, title: String)
+  case updateList(listId: Int, position: Int?, title: String?)
+  case deleteList(listId: Int)
+}
+
+extension ListEndPoint: EndPointable {
+  var environmentBaseURL: String {
+    switch self {
+    case .createList(let boardId, _):
+      return "\(APICredentials.ip)/api/board/\(boardId)/list"
+      
+    case .updateList(let listId, _, _):
+      return "\(APICredentials.ip)/api/list/\(listId)"
+      
+    case .deleteList(let listId):
+      return "\(APICredentials.ip)/api/list/\(listId)"
+    }
+  }
+  
+  var baseURL: URLComponents {
+    guard let url = URLComponents(string: environmentBaseURL) else { fatalError() } // TODO: 예외처리로 바꿔주기
+    return url
+  }
+  
+  var query: HTTPQuery? {
+   return nil
+  }
+  
+  var httpMethod: HTTPMethod? {
+    switch self {
+    case .createList:
+      return .post
+      
+    case .updateList:
+      return .patch
+      
+    case .deleteList:
+      return .delete
+    }
+  }
+  
+  var headers: HTTPHeader? {
+    guard let accessToken = Keychain.shared.loadValue(forKey: "token")
+    else { return nil }
+    
+    return [
+      "Authorization": "\(accessToken)",
+      "Content-Type": "application/x-www-form-urlencoded",
+      "Accept": "application/json"
+    ]
+  }
+  
+  var bodies: HTTPBody? {
+    switch self {
+    case .createList(_, let title):
+      return ["title": title]
+      
+    case .updateList(_, let position, let title):
+      var body = [String: String]()
+      
+      if let position = position {
+        body["position"] = "\(position)"
+      }
+      
+      if let title = title {
+        body["title"] = title
+      }
+      
+      return body
+    default:
+      return nil
+    }
+  }
+}
+
+

--- a/iOS/AreUDone/AreUDone/Service/ListService/ListEndPoint.swift
+++ b/iOS/AreUDone/AreUDone/Service/ListService/ListEndPoint.swift
@@ -12,7 +12,7 @@ import KeychainFramework
 enum ListEndPoint {
   
   case createList(boardId: Int, title: String)
-  case updateList(listId: Int, position: Int?, title: String?)
+  case updateList(listId: Int, position: Double?, title: String?)
   case deleteList(listId: Int)
 }
 

--- a/iOS/AreUDone/AreUDone/Service/ListService/ListService.swift
+++ b/iOS/AreUDone/AreUDone/Service/ListService/ListService.swift
@@ -9,7 +9,16 @@ import Foundation
 import NetworkFramework
 
 protocol ListServiceProtocol {
-  
+  func createList(withBoardId boardId: Int, title: String, completionHandler: @escaping (Result<Void, APIError>) -> Void)
+  func deleteList(withListId listId: Int, completionHandler: @escaping (Result<Void, APIError>) -> Void)
+  func updateList(withListId listId: Int, position: Int?, title: String?, completionHandler: @escaping (Result<Void, APIError>) -> Void)
+}
+
+extension ListServiceProtocol {
+
+  func updateList(withListId listId: Int, position: Int? = nil, title: String? = nil, completionHandler: @escaping (Result<Void, APIError>) -> Void) {
+    updateList(withListId: listId, position: position, title: title, completionHandler: completionHandler)
+  }
 }
 
 class ListService: ListServiceProtocol {
@@ -28,4 +37,21 @@ class ListService: ListServiceProtocol {
   
   // MARK: - Method
   
+  func createList(withBoardId boardId: Int, title: String, completionHandler: @escaping (Result<Void, APIError>) -> Void) {
+    router.request(route: ListEndPoint.createList(boardId: boardId, title: title)) { result in
+      completionHandler(result)
+    }
+  }
+  
+  func deleteList(withListId listId: Int, completionHandler: @escaping (Result<Void, APIError>) -> Void) {
+    router.request(route: ListEndPoint.deleteList(listId: listId)) { result in
+      completionHandler(result)
+    }
+  }
+  
+  func updateList(withListId listId: Int, position: Int?, title: String?, completionHandler: @escaping (Result<Void, APIError>) -> Void) {
+    router.request(route: ListEndPoint.updateList(listId: listId, position: position, title: title)) { result in
+      completionHandler(result)
+    }
+  }
 }

--- a/iOS/AreUDone/AreUDone/Service/ListService/ListService.swift
+++ b/iOS/AreUDone/AreUDone/Service/ListService/ListService.swift
@@ -11,12 +11,12 @@ import NetworkFramework
 protocol ListServiceProtocol {
   func createList(withBoardId boardId: Int, title: String, completionHandler: @escaping (Result<Void, APIError>) -> Void)
   func deleteList(withListId listId: Int, completionHandler: @escaping (Result<Void, APIError>) -> Void)
-  func updateList(withListId listId: Int, position: Int?, title: String?, completionHandler: @escaping (Result<Void, APIError>) -> Void)
+  func updateList(withListId listId: Int, position: Double?, title: String?, completionHandler: @escaping (Result<Void, APIError>) -> Void)
 }
 
 extension ListServiceProtocol {
 
-  func updateList(withListId listId: Int, position: Int? = nil, title: String? = nil, completionHandler: @escaping (Result<Void, APIError>) -> Void) {
+  func updateList(withListId listId: Int, position: Double? = nil, title: String? = nil, completionHandler: @escaping (Result<Void, APIError>) -> Void) {
     updateList(withListId: listId, position: position, title: title, completionHandler: completionHandler)
   }
 }
@@ -49,7 +49,7 @@ class ListService: ListServiceProtocol {
     }
   }
   
-  func updateList(withListId listId: Int, position: Int?, title: String?, completionHandler: @escaping (Result<Void, APIError>) -> Void) {
+  func updateList(withListId listId: Int, position: Double?, title: String?, completionHandler: @escaping (Result<Void, APIError>) -> Void) {
     router.request(route: ListEndPoint.updateList(listId: listId, position: position, title: title)) { result in
       completionHandler(result)
     }

--- a/iOS/AreUDone/AreUDone/Service/UserService/UserService.swift
+++ b/iOS/AreUDone/AreUDone/Service/UserService/UserService.swift
@@ -11,7 +11,7 @@ import NetworkFramework
 protocol UserServiceProtocol {
   
   func requestMe(completionHandler: @escaping ((Result<User, APIError>) -> Void))
-  func fetchUserInfo(userName: String, completionHandler: @escaping ((Result<InvitedUser, APIError>) -> Void))
+  func fetchUserInfo(userName: String, completionHandler: @escaping ((Result<[User], APIError>) -> Void))
 }
 
 class UserService: UserServiceProtocol {
@@ -36,8 +36,8 @@ class UserService: UserServiceProtocol {
     }
   }
   
-  func fetchUserInfo(userName: String, completionHandler: @escaping ((Result<InvitedUser, APIError>) -> Void)) {
-    router.request(route: UserEndPoint.searchUser(userName: userName)) { result in
+  func fetchUserInfo(userName: String, completionHandler: @escaping ((Result<[User], APIError>) -> Void)) {
+    router.request(route: UserEndPoint.searchUser(userName: userName)) { (result: Result<[User], APIError>)  in
       completionHandler(result)
     }
   }

--- a/iOS/AreUDone/AreUDone/SideBarScene/View/SideBarView/CollectionView/MemberCell.swift
+++ b/iOS/AreUDone/AreUDone/SideBarScene/View/SideBarView/CollectionView/MemberCell.swift
@@ -52,7 +52,7 @@ final class MemberCell: UICollectionViewCell, Reusable {
   
   // MARK: - Method
   
-  func update(with imageData: Data, and member: InvitedUser) {
+  func update(with imageData: Data, and member: User) {
     if let image = UIImage(data: imageData) {
       profileImageView.image = image
     }

--- a/iOS/AreUDone/AreUDone/SideBarScene/ViewModel/SideBarViewModel.swift
+++ b/iOS/AreUDone/AreUDone/SideBarScene/ViewModel/SideBarViewModel.swift
@@ -18,7 +18,7 @@ protocol SideBarViewModelProtocol {
   
   func numberOfMembers() -> Int
   func numberOfActivities() -> Int
-  func fetchMember(at index: Int) -> InvitedUser?
+  func fetchMember(at index: Int) -> User?
   func fetchActivity(at index: Int) -> Activity?
   func fetchSectionHeader(at index: Int) -> (image: String, title: String)
   func fetchProfileImage(with url: String, handler: @escaping (Data) -> Void)
@@ -37,7 +37,7 @@ final class SideBarViewModel: SideBarViewModelProtocol {
   private var updateMembersInCollectionViewHandler: (() -> Void)?
   private var updateActivitiesInCollectionViewHandler: (() -> Void)?
   
-  private var boardMembers: [InvitedUser]? {
+  private var boardMembers: [User]? {
     didSet {
       updateMembersInCollectionViewHandler?()
     }
@@ -74,7 +74,11 @@ final class SideBarViewModel: SideBarViewModelProtocol {
     boardService.fetchBoardDetail(with: boardId) { result in
       switch result {
       case .success(let boardDetail):
-        self.boardMembers = boardDetail.invitedUsers
+        var invitedUsers = boardDetail.invitedUsers
+        invitedUsers.insert(boardDetail.creator, at: 0)
+        
+        self.boardMembers = invitedUsers
+        
       case .failure(let error):
         print(error)
       }
@@ -100,7 +104,7 @@ final class SideBarViewModel: SideBarViewModelProtocol {
     return boardActivities?.count ?? 0
   }
   
-  func fetchMember(at index: Int) -> InvitedUser? {
+  func fetchMember(at index: Int) -> User? {
     
     return boardMembers?[index]
   }


### PR DESCRIPTION
# 보드 목록 / 상세 화면의 리스트 기능 나머지 구현

## 📎 해당 이슈

#213 #214 

## 🛠 구현 내용 
- 보드 추가 API 연동
- 보드 목록 API 연동
- 보드 제목 변경 API 연동
- 리스트 제목 변경 API 연동
- 리스트 추가 API 연동
- 리스트 드래그 앤 드랍 시 position 바꾸는 로직 구현
- 카드 폰트 변경
- 배경색 적용
- 사이드바 보드 creator 도 표시되도록 변경

## 🙋‍ 리뷰어 참고 사항 

PR 을 좀 나눴어야했는데... 죄송합니다 

컨플릭트 해결하고 list 타이틀 바꿔봤는데 안되길래 뭐가 문제인지 계속 찾아보다가 겨우 찾아냈네요..
![image](https://user-images.githubusercontent.com/20080283/101604881-dcb57a00-3a44-11eb-9b07-6f2548b041ab.png)
http method 를 대문자로 안해서 그런 것 같습니다 ㅎㅎ; 다른 method 들은 정상 작동하는데 patch 만 이러네요.
