### PR TITLE
Calendar화면 card swipe 기능 수정

### DIFF
--- a/iOS/AreUDone/AreUDone/CalendarScene/View/CardCollectionView/CardCollectionViewCell.swift
+++ b/iOS/AreUDone/AreUDone/CalendarScene/View/CardCollectionView/CardCollectionViewCell.swift
@@ -50,7 +50,7 @@ final class CardCollectionViewCell: UICollectionViewCell, Reusable {
   }()
   
   var delegate: CardCellDelegate?
-  
+  var isSwiped: Bool = false
   
   // MARK:- Initializer
   
@@ -171,9 +171,11 @@ extension CardCollectionViewCell: UIScrollViewDelegate {
     if scrollView.contentOffset.x <= 0 {
       scrollView.bounces = false
       scrollView.contentOffset.x = 0
+      isSwiped = false
     } else {
       scrollView.bounces = true
       delegate?.resetCellOffset(without: self)
+      isSwiped = true
     }
   }
 }

--- a/iOS/AreUDone/AreUDone/CalendarScene/View/Controller/CalendarViewController.swift
+++ b/iOS/AreUDone/AreUDone/CalendarScene/View/Controller/CalendarViewController.swift
@@ -20,12 +20,12 @@ final class CalendarViewController: UIViewController {
   
   private let viewModel: CalendarViewModelProtocol
   weak var calendarCoordinator: CalendarCoordinator?
-
+  
   private lazy var dataSource = configureDataSource()
-
+  
   @IBOutlet weak var dateStepper: DateStepper!
   @IBOutlet weak var cardCollectionView: CardCollectionView!
-
+  
   
   // MARK: - Initializer
   
@@ -175,6 +175,14 @@ extension CalendarViewController: CardCellDelegate {
   }
   
   func didSelect(for cell: CardCollectionViewCell) {
+    guard let visibleCells = cardCollectionView.visibleCells as? [CardCollectionViewCell] else { return }
+    for visibleCell in visibleCells {
+      if visibleCell.isSwiped {
+        cardCollectionView.resetVisibleCellOffset()
+        return
+      }
+    }
+    
     if let indexPath = cardCollectionView.indexPath(for: cell),
        let card = dataSource.itemIdentifier(for: indexPath) {
       calendarCoordinator?.showCardDetail(for: card.id)


### PR DESCRIPTION
# Calendar화면 card swipe 기능 수정

## 📎 해당 이슈
#228 

## 🛠 구현 내용 

- 카드가 swipe 된 상태에서 collectionview의 cell을 터치 했을 때 detail 화면으로 가지않고 swipe가 해제되도록 수정

## 🙋‍ 리뷰어 참고 사항 
없습니다
