### PR TITLE
Calendar화면에서 모든 카드와 내가 즐겨찾는 카드로 분리하여 표시

### DIFF
--- a/iOS/AreUDone/AreUDone.xcodeproj/project.pbxproj
+++ b/iOS/AreUDone/AreUDone.xcodeproj/project.pbxproj
@@ -303,6 +303,7 @@
 		BD59A701257F7A2A00BF8928 /* MonthCardCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD59A700257F7A2A00BF8928 /* MonthCardCount.swift */; };
 		BD59A7122580D98000BF8928 /* Week.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD59A7112580D97F00BF8928 /* Week.swift */; };
 		BD59A745258209BE00BF8928 /* TitleChangeable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD59A744258209BD00BF8928 /* TitleChangeable.swift */; };
+		BD59A74A258212A700BF8928 /* FetchDailyCardsOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD59A749258212A700BF8928 /* FetchDailyCardsOption.swift */; };
 		BDD18AB425653CE5005DF00A /* UIStoryboard+.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD18AB325653CE5005DF00A /* UIStoryboard+.swift */; };
 		BDD18ABD2565449D005DF00A /* SceneCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD18ABC2565449D005DF00A /* SceneCoordinator.swift */; };
 		BDD18AC5256544C6005DF00A /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD18AC4256544C6005DF00A /* Coordinator.swift */; };
@@ -539,6 +540,7 @@
 		BD59A700257F7A2A00BF8928 /* MonthCardCount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthCardCount.swift; sourceTree = "<group>"; };
 		BD59A7112580D97F00BF8928 /* Week.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Week.swift; sourceTree = "<group>"; };
 		BD59A744258209BD00BF8928 /* TitleChangeable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleChangeable.swift; sourceTree = "<group>"; };
+		BD59A749258212A700BF8928 /* FetchDailyCardsOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchDailyCardsOption.swift; sourceTree = "<group>"; };
 		BDD18AB325653CE5005DF00A /* UIStoryboard+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStoryboard+.swift"; sourceTree = "<group>"; };
 		BDD18ABC2565449D005DF00A /* SceneCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneCoordinator.swift; sourceTree = "<group>"; };
 		BDD18AC4256544C6005DF00A /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
@@ -1442,6 +1444,7 @@
 				BD59A60E25787C6300BF8928 /* Font.swift */,
 				BD59A7112580D97F00BF8928 /* Week.swift */,
 				BD59A744258209BD00BF8928 /* TitleChangeable.swift */,
+				BD59A749258212A700BF8928 /* FetchDailyCardsOption.swift */,
 			);
 			path = Constants;
 			sourceTree = "<group>";
@@ -1744,6 +1747,7 @@
 				BD2AA7C3256E3D3600EA8791 /* CardDetail.swift in Sources */,
 				3373A49A2578DEC300D92CC0 /* MemberFooterView.swift in Sources */,
 				335AC4E6256F7988006A5C4A /* BoardListJsonFactory.swift in Sources */,
+				BD59A74A258212A700BF8928 /* FetchDailyCardsOption.swift in Sources */,
 				336011FE256D5CFE009580A1 /* String+.swift in Sources */,
 				33F2D4F8257B582C008F1E06 /* InvitationTableViewCell.swift in Sources */,
 				3360122A256E5022009580A1 /* BoardListCoordinator.swift in Sources */,

--- a/iOS/AreUDone/AreUDone.xcodeproj/project.pbxproj
+++ b/iOS/AreUDone/AreUDone.xcodeproj/project.pbxproj
@@ -189,11 +189,6 @@
 		33F2D551257DE9C7008F1E06 /* BoardAddTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F2D550257DE9C7008F1E06 /* BoardAddTableView.swift */; };
 		33F2D55F257DF349008F1E06 /* BoardColorTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F2D55E257DF349008F1E06 /* BoardColorTableViewCell.swift */; };
 		33F2D567257E2389008F1E06 /* BoardAddTableViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F2D566257E2389008F1E06 /* BoardAddTableViewDataSource.swift */; };
-		33F2D6A2257F41EB008F1E06 /* BoardDetailCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F2D6A1257F41EA008F1E06 /* BoardDetailCollectionView.swift */; };
-		33F2D6AA257F56C8008F1E06 /* ListEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F2D6A9257F56C8008F1E06 /* ListEndPoint.swift */; };
-		33F2D6BD257F7635008F1E06 /* MembersCollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F2D6BC257F7635008F1E06 /* MembersCollectionViewDataSource.swift */; };
-		33F2D6C5257F7D9F008F1E06 /* BoardDetailCollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F2D6C4257F7D9F008F1E06 /* BoardDetailCollectionViewDataSource.swift */; };
-		33F2D6CA257F838D008F1E06 /* ListCollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F2D6C9257F838D008F1E06 /* ListCollectionViewDataSource.swift */; };
 		33F2D58D257E678C008F1E06 /* BoardServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F2D58C257E678C008F1E06 /* BoardServiceTests.swift */; };
 		33F2D591257E69FF008F1E06 /* CardDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2AA7C2256E3D3600EA8791 /* CardDetail.swift */; };
 		33F2D595257E6A05008F1E06 /* ImageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 333BA5CE25787F290057ACA4 /* ImageService.swift */; };
@@ -215,7 +210,7 @@
 		33F2D5D5257E6A78008F1E06 /* SideBarCollectionViewActivityCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 333BA56725769F9F0057ACA4 /* SideBarCollectionViewActivityCell.swift */; };
 		33F2D5D9257E6A7B008F1E06 /* SideBarCollectionViewMembersCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 333BA59E2577BB570057ACA4 /* SideBarCollectionViewMembersCell.swift */; };
 		33F2D5DD257E6A7E008F1E06 /* MemberCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F2D4A7257A3F6C008F1E06 /* MemberCollectionView.swift */; };
-		33F2D5E1257E6A80008F1E06 /* MembersCollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F2D4B8257A8D0A008F1E06 /* MembersCollectionViewDataSource.swift */; };
+		33F2D5E1257E6A80008F1E06 /* (null) in Sources */ = {isa = PBXBuildFile; };
 		33F2D5E5257E6A82008F1E06 /* MemberFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3373A4992578DEC300D92CC0 /* MemberFooterView.swift */; };
 		33F2D5E9257E6A85008F1E06 /* MemberCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 333BA5A62577C0440057ACA4 /* MemberCell.swift */; };
 		33F2D5ED257E6A8F008F1E06 /* BoardDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 333BA56C25776ABE0057ACA4 /* BoardDetail.swift */; };
@@ -258,6 +253,11 @@
 		33F2D68F257E6C4F008F1E06 /* PaddingLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2AA89A2574A2C000EA8791 /* PaddingLabel.swift */; };
 		33F2D696257E6F43008F1E06 /* AlertFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEA7BEA2576385000CF6B11 /* AlertFactory.swift */; };
 		33F2D69A257E6FB0008F1E06 /* UIAlertController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDEA7BEF25763AB300CF6B11 /* UIAlertController+.swift */; };
+		33F2D6A2257F41EB008F1E06 /* BoardDetailCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F2D6A1257F41EA008F1E06 /* BoardDetailCollectionView.swift */; };
+		33F2D6AA257F56C8008F1E06 /* ListEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F2D6A9257F56C8008F1E06 /* ListEndPoint.swift */; };
+		33F2D6BD257F7635008F1E06 /* MembersCollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F2D6BC257F7635008F1E06 /* MembersCollectionViewDataSource.swift */; };
+		33F2D6C5257F7D9F008F1E06 /* BoardDetailCollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F2D6C4257F7D9F008F1E06 /* BoardDetailCollectionViewDataSource.swift */; };
+		33F2D6CA257F838D008F1E06 /* ListCollectionViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F2D6C9257F838D008F1E06 /* ListCollectionViewDataSource.swift */; };
 		33F66CE92567A17C00959401 /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F66CE82567A17C00959401 /* UIViewController+.swift */; };
 		BD2AA727256CBE7600EA8791 /* CardCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2AA726256CBE7600EA8791 /* CardCollectionView.swift */; };
 		BD2AA72D256CBEB400EA8791 /* CardCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2AA72B256CBEB400EA8791 /* CardCollectionViewCell.swift */; };
@@ -302,6 +302,7 @@
 		BD59A6FC257F514D00BF8928 /* MemberUpdateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD59A688257E163100BF8928 /* MemberUpdateViewModel.swift */; };
 		BD59A701257F7A2A00BF8928 /* MonthCardCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD59A700257F7A2A00BF8928 /* MonthCardCount.swift */; };
 		BD59A7122580D98000BF8928 /* Week.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD59A7112580D97F00BF8928 /* Week.swift */; };
+		BD59A745258209BE00BF8928 /* TitleChangeable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD59A744258209BD00BF8928 /* TitleChangeable.swift */; };
 		BDD18AB425653CE5005DF00A /* UIStoryboard+.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD18AB325653CE5005DF00A /* UIStoryboard+.swift */; };
 		BDD18ABD2565449D005DF00A /* SceneCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD18ABC2565449D005DF00A /* SceneCoordinator.swift */; };
 		BDD18AC5256544C6005DF00A /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDD18AC4256544C6005DF00A /* Coordinator.swift */; };
@@ -489,12 +490,12 @@
 		33F2D550257DE9C7008F1E06 /* BoardAddTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardAddTableView.swift; sourceTree = "<group>"; };
 		33F2D55E257DF349008F1E06 /* BoardColorTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardColorTableViewCell.swift; sourceTree = "<group>"; };
 		33F2D566257E2389008F1E06 /* BoardAddTableViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardAddTableViewDataSource.swift; sourceTree = "<group>"; };
+		33F2D58C257E678C008F1E06 /* BoardServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardServiceTests.swift; sourceTree = "<group>"; };
 		33F2D6A1257F41EA008F1E06 /* BoardDetailCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardDetailCollectionView.swift; sourceTree = "<group>"; };
 		33F2D6A9257F56C8008F1E06 /* ListEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListEndPoint.swift; sourceTree = "<group>"; };
 		33F2D6BC257F7635008F1E06 /* MembersCollectionViewDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MembersCollectionViewDataSource.swift; sourceTree = "<group>"; };
 		33F2D6C4257F7D9F008F1E06 /* BoardDetailCollectionViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardDetailCollectionViewDataSource.swift; sourceTree = "<group>"; };
 		33F2D6C9257F838D008F1E06 /* ListCollectionViewDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListCollectionViewDataSource.swift; sourceTree = "<group>"; };
-		33F2D58C257E678C008F1E06 /* BoardServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardServiceTests.swift; sourceTree = "<group>"; };
 		33F66CE82567A17C00959401 /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
 		BD2AA726256CBE7600EA8791 /* CardCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardCollectionView.swift; sourceTree = "<group>"; };
 		BD2AA72B256CBEB400EA8791 /* CardCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -537,6 +538,7 @@
 		BD59A6F0257F3D5A00BF8928 /* CommentEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentEndPoint.swift; sourceTree = "<group>"; };
 		BD59A700257F7A2A00BF8928 /* MonthCardCount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthCardCount.swift; sourceTree = "<group>"; };
 		BD59A7112580D97F00BF8928 /* Week.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Week.swift; sourceTree = "<group>"; };
+		BD59A744258209BD00BF8928 /* TitleChangeable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleChangeable.swift; sourceTree = "<group>"; };
 		BDD18AB325653CE5005DF00A /* UIStoryboard+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStoryboard+.swift"; sourceTree = "<group>"; };
 		BDD18ABC2565449D005DF00A /* SceneCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneCoordinator.swift; sourceTree = "<group>"; };
 		BDD18AC4256544C6005DF00A /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
@@ -1439,6 +1441,7 @@
 				336010CC256B7B2B009580A1 /* APICredentials.swift */,
 				BD59A60E25787C6300BF8928 /* Font.swift */,
 				BD59A7112580D97F00BF8928 /* Week.swift */,
+				BD59A744258209BD00BF8928 /* TitleChangeable.swift */,
 			);
 			path = Constants;
 			sourceTree = "<group>";
@@ -1761,6 +1764,7 @@
 				BD2AA7B5256DFBCD00EA8791 /* CardDetailCoordinator.swift in Sources */,
 				335AC4CF256F6C51006A5C4A /* SectionContentFactory.swift in Sources */,
 				335AC521256FDFD8006A5C4A /* List.swift in Sources */,
+				BD59A745258209BE00BF8928 /* TitleChangeable.swift in Sources */,
 				BD59A6C7257F13E200BF8928 /* UserInfo.swift in Sources */,
 				33EE01662568DFF6003D3221 /* TabbarCoordinator.swift in Sources */,
 				BDD18B882567A0C5005DF00A /* SigninChecker.swift in Sources */,
@@ -1956,7 +1960,7 @@
 				33638E8C2573F910006033CF /* BoardDetailViewModel.swift in Sources */,
 				33F2D625257E6B1A008F1E06 /* UITableView+.swift in Sources */,
 				33F2D609257E6AD1008F1E06 /* ContentInputCoordinator.swift in Sources */,
-				33F2D5E1257E6A80008F1E06 /* MembersCollectionViewDataSource.swift in Sources */,
+				33F2D5E1257E6A80008F1E06 /* (null) in Sources */,
 				33601112256B9156009580A1 /* MockRouter.swift in Sources */,
 				33F2D62D257E6B25008F1E06 /* UserJsonFactory.swift in Sources */,
 				33F2D67F257E6BE6008F1E06 /* CommentCollectionViewHeader.swift in Sources */,

--- a/iOS/AreUDone/AreUDone/BoardListScene/View/Controller/BoardListViewController.swift
+++ b/iOS/AreUDone/AreUDone/BoardListScene/View/Controller/BoardListViewController.swift
@@ -175,8 +175,8 @@ extension BoardListViewController: UICollectionViewDelegate {
 
 extension BoardListViewController: CustomSegmentedControlDelegate {
   
-  func change(to title: TitleChangeable) {
-    self.titleView.text = title.text
+  func change(to segmented: TitleChangeable) {
+    titleView.text = segmented.text
     UIView.transition(
       with: titleView,
       duration: 0.3,
@@ -184,7 +184,7 @@ extension BoardListViewController: CustomSegmentedControlDelegate {
       animations: nil,
       completion: nil)
     
-    switch title {
+    switch segmented {
     case BoardSegment.myBoard:
       viewModel.fetchMyBoard()
       

--- a/iOS/AreUDone/AreUDone/BoardListScene/View/Controller/BoardListViewController.swift
+++ b/iOS/AreUDone/AreUDone/BoardListScene/View/Controller/BoardListViewController.swift
@@ -60,17 +60,6 @@ final class BoardListViewController: UIViewController {
       let boardTitles = BoardSegment.allCases.map { $0.rawValue }
       segmentControl.setButtonTitles(buttonTitles: boardTitles)
       segmentControl.delegate = self
-      
-      segmentControl.layer.cornerRadius = 10
-      segmentControl.layer.maskedCorners = [
-        .layerMinXMaxYCorner,
-        .layerMaxXMaxYCorner
-      ]
-      segmentControl.addShadow(
-        offset: CGSize(width: 0, height: -1),
-        radius: 2,
-        opacity: 0.5
-      )
     }
   }
   

--- a/iOS/AreUDone/AreUDone/BoardListScene/View/Controller/BoardListViewController.swift
+++ b/iOS/AreUDone/AreUDone/BoardListScene/View/Controller/BoardListViewController.swift
@@ -16,13 +16,9 @@ final class BoardListViewController: UIViewController {
   
   
   // MARK: - Enum
+  
   enum Section {
     case main
-  }
-  
-  enum BoardSegment: String, CaseIterable {
-    case myBoard = "나의 보드"
-    case invitedBoard = "공유 보드"
   }
   
   
@@ -57,7 +53,7 @@ final class BoardListViewController: UIViewController {
   }
   @IBOutlet weak var segmentControl: CustomSegmentedControl! {
     didSet {
-      let boardTitles = BoardSegment.allCases.map { $0.rawValue }
+      let boardTitles = BoardSegment.allCases.map { $0.text }
       segmentControl.setButtonTitles(buttonTitles: boardTitles)
       segmentControl.delegate = self
     }
@@ -179,8 +175,8 @@ extension BoardListViewController: UICollectionViewDelegate {
 
 extension BoardListViewController: CustomSegmentedControlDelegate {
   
-  func change(to title: String) {
-    self.titleView.text = title
+  func change(to title: TitleChangeable) {
+    self.titleView.text = title.text
     UIView.transition(
       with: titleView,
       duration: 0.3,
@@ -189,9 +185,10 @@ extension BoardListViewController: CustomSegmentedControlDelegate {
       completion: nil)
     
     switch title {
-    case BoardSegment.myBoard.rawValue:
+    case BoardSegment.myBoard:
       viewModel.fetchMyBoard()
-    case BoardSegment.invitedBoard.rawValue:
+      
+    case BoardSegment.invitedBoard:
       viewModel.fetchInvitedBoard()
     default:
       break

--- a/iOS/AreUDone/AreUDone/CalendarPickerScene/CalendarPickerViewCoordinator.swift
+++ b/iOS/AreUDone/AreUDone/CalendarPickerScene/CalendarPickerViewCoordinator.swift
@@ -20,7 +20,7 @@ final class CalendarPickerViewCoordinator: NavigationCoordinator {
   }
   
   func start() -> UIViewController {
-    let cardService = CardService(router: MockRouter(jsonFactory: CardTrueJsonFactory()))
+    let cardService = CardService(router: router)
     let viewModel = CalendarPickerViewModel(cardService: cardService)
     viewModel.selectedDate = selectedDate
     

--- a/iOS/AreUDone/AreUDone/CalendarPickerScene/ViewModel/CalendarPickerViewModel.swift
+++ b/iOS/AreUDone/AreUDone/CalendarPickerScene/ViewModel/CalendarPickerViewModel.swift
@@ -31,7 +31,6 @@ final class CalendarPickerViewModel: CalendarPickerViewModelProtocol {
   var selectedDate: Date!
   private lazy var basedate: Date! = selectedDate
   private let cardService: CardServiceProtocol
-  private var type = "me"
   private var countDictionary = [String: Int]()
   
   private let calendar = Calendar(identifier: .gregorian)
@@ -97,8 +96,7 @@ final class CalendarPickerViewModel: CalendarPickerViewModelProtocol {
     
     cardService.fetchCardsCount(
       startDate: startDateAsString,
-      endDate: endDateAsString,
-      member: type
+      endDate: endDateAsString
     ) { [weak self] result in
       switch result {
       case .success(let monthCardCount):

--- a/iOS/AreUDone/AreUDone/CalendarScene/CalendarCoordinator.swift
+++ b/iOS/AreUDone/AreUDone/CalendarScene/CalendarCoordinator.swift
@@ -35,8 +35,9 @@ final class CalendarCoordinator: NavigationCoordinator {
     
     guard let calendarViewController = storyboard.instantiateViewController(
             identifier: CalendarViewController.identifier,
-            creator: { coder in
-              let cardService = CardService(router: MockRouter(jsonFactory: CardTrueJsonFactory()))
+            creator: { [weak self] coder in
+              guard let self = self else { return UIViewController() }
+              let cardService = CardService(router: self.router)
               let viewModel = CalendarViewModel(cardService: cardService)
               return CalendarViewController(coder: coder, viewModel: viewModel)
             }) as? CalendarViewController

--- a/iOS/AreUDone/AreUDone/CalendarScene/Resources/Calendar.storyboard
+++ b/iOS/AreUDone/AreUDone/CalendarScene/Resources/Calendar.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -16,41 +16,9 @@
                     <view key="view" contentMode="scaleToFill" id="H7c-pU-k8V">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="wBe-Ft-hdO" customClass="CardCollectionView" customModule="AreUDone" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="862"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="kIG-4x-SJi">
-                                    <size key="itemSize" width="128" height="128"/>
-                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
-                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
-                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
-                                </collectionViewFlowLayout>
-                                <cells/>
-                            </collectionView>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vCS-Xe-Iy9" customClass="DateStepper" customModule="AreUDone" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="44" width="414" height="134.5"/>
-                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                            </view>
-                        </subviews>
                         <viewLayoutGuide key="safeArea" id="Mzv-cZ-RHA"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                        <constraints>
-                            <constraint firstItem="vCS-Xe-Iy9" firstAttribute="centerX" secondItem="H7c-pU-k8V" secondAttribute="centerX" id="6b8-bS-isM"/>
-                            <constraint firstItem="Mzv-cZ-RHA" firstAttribute="trailing" secondItem="vCS-Xe-Iy9" secondAttribute="trailing" id="9DJ-n4-0Iw"/>
-                            <constraint firstItem="vCS-Xe-Iy9" firstAttribute="top" secondItem="Mzv-cZ-RHA" secondAttribute="top" id="CNq-Sf-kdf"/>
-                            <constraint firstItem="wBe-Ft-hdO" firstAttribute="leading" secondItem="Mzv-cZ-RHA" secondAttribute="leading" id="NWa-5X-UZ7"/>
-                            <constraint firstItem="Mzv-cZ-RHA" firstAttribute="trailing" secondItem="wBe-Ft-hdO" secondAttribute="trailing" id="V9L-pL-0ZQ"/>
-                            <constraint firstItem="vCS-Xe-Iy9" firstAttribute="leading" secondItem="Mzv-cZ-RHA" secondAttribute="leading" id="daI-Nb-wMa"/>
-                            <constraint firstItem="vCS-Xe-Iy9" firstAttribute="height" secondItem="H7c-pU-k8V" secondAttribute="height" multiplier="0.15" id="i9Q-es-Hrh"/>
-                            <constraint firstItem="Mzv-cZ-RHA" firstAttribute="bottom" secondItem="wBe-Ft-hdO" secondAttribute="bottom" id="t1b-zO-qaH"/>
-                            <constraint firstAttribute="top" secondItem="wBe-Ft-hdO" secondAttribute="top" id="vYT-dL-zbP"/>
-                        </constraints>
+                        <color key="backgroundColor" systemColor="systemGray6Color"/>
                     </view>
-                    <connections>
-                        <outlet property="cardCollectionView" destination="wBe-Ft-hdO" id="vxT-eo-pav"/>
-                        <outlet property="dateStepper" destination="vCS-Xe-Iy9" id="mh2-uH-BbJ"/>
-                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="4gg-Ph-4IS" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
@@ -58,8 +26,8 @@
         </scene>
     </scenes>
     <resources>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        <systemColor name="systemGray6Color">
+            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/iOS/AreUDone/AreUDone/CalendarScene/Resources/Calendar.storyboard
+++ b/iOS/AreUDone/AreUDone/CalendarScene/Resources/Calendar.storyboard
@@ -8,24 +8,97 @@
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
+    <customFonts key="customFonts">
+        <array key="NanumBarunpenB.ttf">
+            <string>NanumBarunpen-Bold</string>
+        </array>
+    </customFonts>
     <scenes>
         <!--Calendar View Controller-->
-        <scene sceneID="wD8-fD-Fzp">
+        <scene sceneID="h1h-jn-ZkT">
             <objects>
-                <viewController storyboardIdentifier="CalendarViewController" id="wCX-r5-nRh" customClass="CalendarViewController" customModule="AreUDone" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="H7c-pU-k8V">
+                <viewController storyboardIdentifier="CalendarViewController" id="dww-qn-DTV" customClass="CalendarViewController" customModule="AreUDone" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="2ij-hR-TD9">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <viewLayoutGuide key="safeArea" id="Mzv-cZ-RHA"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="전체 카드" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZuB-J3-HwS">
+                                <rect key="frame" x="20" y="64" width="112.5" height="55"/>
+                                <fontDescription key="fontDescription" name="NanumBarunpen-Bold" family="NanumBarunpen" pointSize="30"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="26k-J8-FJY">
+                                <rect key="frame" x="10" y="129" width="394" height="713"/>
+                                <subviews>
+                                    <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="Mgr-hO-jXA" customClass="CardCollectionView" customModule="AreUDone" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="0.0" width="394" height="663"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="fLM-tM-eZ2">
+                                            <size key="itemSize" width="128" height="128"/>
+                                            <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                                            <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                                            <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                        </collectionViewFlowLayout>
+                                        <cells/>
+                                    </collectionView>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dlO-vv-bNx" customClass="CustomSegmentedControl" customModule="AreUDone" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="663" width="394" height="50"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="50" id="9on-qu-KVG"/>
+                                        </constraints>
+                                    </view>
+                                </subviews>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="trailing" secondItem="dlO-vv-bNx" secondAttribute="trailing" id="4sc-e9-mjJ"/>
+                                    <constraint firstItem="Mgr-hO-jXA" firstAttribute="top" secondItem="26k-J8-FJY" secondAttribute="top" id="PnE-bD-pxj"/>
+                                    <constraint firstItem="Mgr-hO-jXA" firstAttribute="leading" secondItem="26k-J8-FJY" secondAttribute="leading" id="ZCW-7n-CqJ"/>
+                                    <constraint firstItem="dlO-vv-bNx" firstAttribute="top" secondItem="Mgr-hO-jXA" secondAttribute="bottom" id="ZqY-qu-Uf4"/>
+                                    <constraint firstAttribute="bottom" secondItem="dlO-vv-bNx" secondAttribute="bottom" id="pBO-RN-fXk"/>
+                                    <constraint firstAttribute="trailing" secondItem="Mgr-hO-jXA" secondAttribute="trailing" id="sym-h0-P52"/>
+                                    <constraint firstItem="dlO-vv-bNx" firstAttribute="leading" secondItem="26k-J8-FJY" secondAttribute="leading" id="y1S-Ms-jTM"/>
+                                </constraints>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JjI-Mb-dZ4" customClass="DateStepper" customModule="AreUDone" customModuleProvider="target">
+                                <rect key="frame" x="152.5" y="64.5" width="241.5" height="54"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            </view>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="9a7-qQ-npf"/>
                         <color key="backgroundColor" systemColor="systemGray6Color"/>
+                        <constraints>
+                            <constraint firstItem="26k-J8-FJY" firstAttribute="leading" secondItem="9a7-qQ-npf" secondAttribute="leading" constant="10" id="CSh-J2-mDt"/>
+                            <constraint firstItem="9a7-qQ-npf" firstAttribute="trailing" secondItem="26k-J8-FJY" secondAttribute="trailing" constant="10" id="JTf-hw-NNv"/>
+                            <constraint firstItem="JjI-Mb-dZ4" firstAttribute="height" secondItem="2ij-hR-TD9" secondAttribute="height" multiplier="0.06" id="Rhm-UE-mQ9"/>
+                            <constraint firstItem="JjI-Mb-dZ4" firstAttribute="centerY" secondItem="ZuB-J3-HwS" secondAttribute="centerY" id="Xse-Be-UVw"/>
+                            <constraint firstItem="9a7-qQ-npf" firstAttribute="bottom" secondItem="26k-J8-FJY" secondAttribute="bottom" constant="20" id="bOg-4c-6d9"/>
+                            <constraint firstItem="ZuB-J3-HwS" firstAttribute="top" secondItem="9a7-qQ-npf" secondAttribute="top" constant="20" id="dMk-1h-TeY"/>
+                            <constraint firstItem="ZuB-J3-HwS" firstAttribute="height" secondItem="2ij-hR-TD9" secondAttribute="height" multiplier="0.06" constant="1" id="eEy-W7-9O3"/>
+                            <constraint firstItem="26k-J8-FJY" firstAttribute="top" secondItem="ZuB-J3-HwS" secondAttribute="bottom" constant="10" id="jYP-xz-pZn"/>
+                            <constraint firstItem="JjI-Mb-dZ4" firstAttribute="trailing" secondItem="9a7-qQ-npf" secondAttribute="trailing" constant="-20" id="v7Q-WL-13h"/>
+                            <constraint firstItem="ZuB-J3-HwS" firstAttribute="leading" secondItem="26k-J8-FJY" secondAttribute="leading" constant="10" id="wub-IU-qdU"/>
+                            <constraint firstItem="JjI-Mb-dZ4" firstAttribute="leading" secondItem="ZuB-J3-HwS" secondAttribute="trailing" constant="20" id="xFn-8Z-XUD"/>
+                        </constraints>
                     </view>
+                    <connections>
+                        <outlet property="baseView" destination="26k-J8-FJY" id="SSZ-5X-UfJ"/>
+                        <outlet property="cardCollectionView" destination="Mgr-hO-jXA" id="Xzp-a5-Ofs"/>
+                        <outlet property="dateStepper" destination="JjI-Mb-dZ4" id="BdK-Ja-9lk"/>
+                        <outlet property="segmentedControl" destination="dlO-vv-bNx" id="hnb-Ve-1NA"/>
+                        <outlet property="titleLabel" destination="ZuB-J3-HwS" id="34x-Xy-rd9"/>
+                    </connections>
                 </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="4gg-Ph-4IS" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="ENR-91-Jv3" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="0.0" y="61.607142857142854"/>
+            <point key="canvasLocation" x="233" y="60"/>
         </scene>
     </scenes>
     <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
         <systemColor name="systemGray6Color">
             <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>

--- a/iOS/AreUDone/AreUDone/CalendarScene/View/CardCollectionView/CardCollectionView.swift
+++ b/iOS/AreUDone/AreUDone/CalendarScene/View/CardCollectionView/CardCollectionView.swift
@@ -43,8 +43,12 @@ final class CardCollectionView: UICollectionView {
 private extension CardCollectionView {
   
   func configure() {
-    let height = UIScreen.main.bounds.height * 0.15
-    contentInset = UIEdgeInsets(top: height, left: 0, bottom: height / 2, right: 0)
+    layer.cornerRadius = 10
+    layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+    contentInset = UIEdgeInsets(top: 10, left: 0, bottom: 10, right: 0)
+    backgroundColor = .white
+    showsVerticalScrollIndicator = false
+    showsHorizontalScrollIndicator = false
     
     register(CardCollectionViewCell.self)
     configureFlowLayout()

--- a/iOS/AreUDone/AreUDone/CalendarScene/View/Controller/CalendarViewController.swift
+++ b/iOS/AreUDone/AreUDone/CalendarScene/View/Controller/CalendarViewController.swift
@@ -20,11 +20,11 @@ final class CalendarViewController: UIViewController {
   
   private let viewModel: CalendarViewModelProtocol
   weak var calendarCoordinator: CalendarCoordinator?
-
+  
   private lazy var dataSource = configureDataSource()
-
+  
   @IBOutlet weak var cardCollectionView: CardCollectionView!
-
+  
   @IBOutlet weak var baseView: UIView! {
     didSet {
       baseView.backgroundColor = .clear
@@ -42,7 +42,7 @@ final class CalendarViewController: UIViewController {
       titleLabel.text = "전체 카드"
     }
   }
-
+  
   @IBOutlet weak var dateStepper: DateStepper!
   
   @IBOutlet private weak var segmentedControl: CustomSegmentedControl! {
@@ -51,8 +51,7 @@ final class CalendarViewController: UIViewController {
       segmentedControl.setButtonTitles(buttonTitles: titles)
     }
   }
-
-
+  
   
   // MARK: - Initializer
   
@@ -121,9 +120,8 @@ private extension CalendarViewController {
   func configure() {
     segmentedControl.delegate = self
     cardCollectionView.delegate = self
-    viewModel.fetchInitializeDailyCards()
-    
     dateStepper.delegate = self
+    
     viewModel.initializeDate()
   }
 }
@@ -134,17 +132,8 @@ private extension CalendarViewController {
 private extension CalendarViewController {
   
   func bindUI() {
-    bindingInitializeCardCollectionView()
     bindingUpdateCardCollectionView()
     bindingUpdateDate()
-  }
-  
-  func bindingInitializeCardCollectionView() {
-    viewModel.bindingInitializeCardCollectionView { [weak self] cards in
-      DispatchQueue.main.async {
-        self?.updateSnapshot(with: cards, animatingDifferences: false)
-      }
-    }
   }
   
   func bindingUpdateCardCollectionView() {
@@ -156,8 +145,10 @@ private extension CalendarViewController {
   }
   
   func bindingUpdateDate() {
-    viewModel.bindingUpdateDate { date in
-      self.dateStepper.updateDate(date: date)
+    viewModel.bindingUpdateDate { [weak self] date in
+      DispatchQueue.main.async {
+        self?.dateStepper.updateDate(date: date)
+      }
     }
   }
 }

--- a/iOS/AreUDone/AreUDone/CalendarScene/View/Controller/CalendarViewController.swift
+++ b/iOS/AreUDone/AreUDone/CalendarScene/View/Controller/CalendarViewController.swift
@@ -13,8 +13,8 @@ enum Section {
 
 final class CalendarViewController: UIViewController {
   
-  typealias DataSource = UICollectionViewDiffableDataSource<String, Card>
-  typealias Snapshot = NSDiffableDataSourceSnapshot<String, Card>
+  typealias DataSource = UICollectionViewDiffableDataSource<Section, Card>
+  typealias Snapshot = NSDiffableDataSourceSnapshot<Section, Card>
   
   // MARK: - Property
   
@@ -66,7 +66,8 @@ final class CalendarViewController: UIViewController {
   private lazy var segmentedControl: CustomSegmentedControl = {
     let segmentedControl = CustomSegmentedControl()
     segmentedControl.translatesAutoresizingMaskIntoConstraints = false
-    segmentedControl.setButtonTitles(buttonTitles: ["전체카드", "나의 카드"])
+    let titles = CardSegment.allCases.map { $0.text }
+    segmentedControl.setButtonTitles(buttonTitles: titles)
     
     return segmentedControl
   }()
@@ -124,7 +125,7 @@ private extension CalendarViewController {
     guard let cards = item.cards else { return }
     var snapshot = Snapshot()
     
-    snapshot.appendSections([""])
+    snapshot.appendSections([.main])
     snapshot.appendItems(cards)
     
     dataSource.apply(snapshot, animatingDifferences: animatingDifferences)
@@ -137,6 +138,7 @@ private extension CalendarViewController {
 private extension CalendarViewController {
   
   func configure() {
+    segmentedControl.delegate = self
     cardCollectionView.delegate = self
     viewModel.fetchInitializeDailyCards()
     
@@ -301,5 +303,21 @@ extension CalendarViewController: UICollectionViewDelegate {
   
   func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
     cardCollectionView.resetVisibleCellOffset()
+  }
+}
+
+
+// MARK:- Extension CustomSegmentedControlDelegate
+
+extension CalendarViewController: CustomSegmentedControlDelegate {
+  
+  func change(to title: TitleChangeable) {
+    self.titleLabel.text = title.text
+    UIView.transition(
+      with: titleLabel,
+      duration: 0.3,
+      options: .transitionFlipFromLeft,
+      animations: nil,
+      completion: nil)
   }
 }

--- a/iOS/AreUDone/AreUDone/CalendarScene/View/Controller/CalendarViewController.swift
+++ b/iOS/AreUDone/AreUDone/CalendarScene/View/Controller/CalendarViewController.swift
@@ -77,6 +77,7 @@ final class CalendarViewController: UIViewController {
   
   override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
+    viewModel.fetchUpdateDailyCards()
     navigationController?.navigationBar.isHidden = true
   }
 }
@@ -121,8 +122,6 @@ private extension CalendarViewController {
     segmentedControl.delegate = self
     cardCollectionView.delegate = self
     dateStepper.delegate = self
-    
-    viewModel.initializeDate()
   }
 }
 
@@ -237,7 +236,6 @@ extension CalendarViewController: CustomSegmentedControlDelegate {
     switch segmented {
     case CardSegment.allCard:
       viewModel.fetchUpdateDailyCards(withOption: .allCard)
-      
     case CardSegment.myCard:
       viewModel.fetchUpdateDailyCards(withOption: .myCard)
       

--- a/iOS/AreUDone/AreUDone/CalendarScene/View/Controller/CalendarViewController.swift
+++ b/iOS/AreUDone/AreUDone/CalendarScene/View/Controller/CalendarViewController.swift
@@ -162,11 +162,16 @@ extension CalendarViewController: CalendarPickerViewControllerDelegate {
 extension CalendarViewController: CardCellDelegate {
   
   func remove(cell: CardCollectionViewCell) {
-    if let indexPath = cardCollectionView.indexPath(for: cell),
-       let item = dataSource.itemIdentifier(for: indexPath) {
-      var snapshot = dataSource.snapshot()
+    guard
+      let indexPath = cardCollectionView.indexPath(for: cell),
+      let item = dataSource.itemIdentifier(for: indexPath)
+    else { return }
+    
+    viewModel.deleteCard(for: item.id) { [weak self] in
+      guard let self = self else { return }
+      var snapshot = self.dataSource.snapshot()
       snapshot.deleteItems([item])
-      
+      self.dataSource.apply(snapshot)
     }
   }
   

--- a/iOS/AreUDone/AreUDone/CalendarScene/View/Controller/CalendarViewController.swift
+++ b/iOS/AreUDone/AreUDone/CalendarScene/View/Controller/CalendarViewController.swift
@@ -23,8 +23,53 @@ final class CalendarViewController: UIViewController {
 
   private lazy var dataSource = configureDataSource()
 
-  @IBOutlet weak var dateStepper: DateStepper!
-  @IBOutlet weak var cardCollectionView: CardCollectionView!
+  private lazy var cardCollectionView: CardCollectionView = {
+    let flowLayout = UICollectionViewFlowLayout()
+    let collectionView = CardCollectionView(
+      frame: CGRect.zero,
+      collectionViewLayout: flowLayout
+    )
+    collectionView.translatesAutoresizingMaskIntoConstraints = false
+    
+    return collectionView
+  }()
+  
+  private lazy var baseView: UIView = {
+    let view = UIView()
+    view.translatesAutoresizingMaskIntoConstraints = false
+    view.backgroundColor = .clear
+    view.addShadow(
+      offset: .zero,
+      radius: 3,
+      opacity: 0.5
+    )
+    
+    return view
+  }()
+  
+  private lazy var titleLabel: UILabel = {
+    let label = UILabel()
+    label.translatesAutoresizingMaskIntoConstraints = false
+    label.font = UIFont.nanumB(size: 30)
+    label.text = "전체 카드"
+    
+    return label
+  }()
+  
+  private lazy var dateStepper: DateStepper = {
+    let dateStepper = DateStepper()
+    dateStepper.translatesAutoresizingMaskIntoConstraints = false
+    
+    return dateStepper
+  }()
+  
+  private lazy var segmentedControl: CustomSegmentedControl = {
+    let segmentedControl = CustomSegmentedControl()
+    segmentedControl.translatesAutoresizingMaskIntoConstraints = false
+    segmentedControl.setButtonTitles(buttonTitles: ["전체카드", "나의 카드"])
+    
+    return segmentedControl
+  }()
 
   
   // MARK: - Initializer
@@ -97,6 +142,65 @@ private extension CalendarViewController {
     
     dateStepper.delegate = self
     viewModel.initializeDate()
+    
+    configureView()
+    configureTitleLabel()
+    configureDateStepper()
+    configureBaseView()
+    configureCardCollectionView()
+    configureSegmentedControl()
+  }
+  
+  func configureView() {
+    view.addSubview(titleLabel)
+    view.addSubview(dateStepper)
+    view.addSubview(baseView)
+    baseView.addSubview(cardCollectionView)
+    baseView.addSubview(segmentedControl)
+  }
+  
+  func configureTitleLabel() {
+    NSLayoutConstraint.activate([
+      titleLabel.leadingAnchor.constraint(equalTo: baseView.leadingAnchor, constant: 10),
+      titleLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 20),
+      titleLabel.heightAnchor.constraint(equalTo: view.heightAnchor, multiplier: 0.06)
+    ])
+  }
+  
+  func configureDateStepper() {
+    NSLayoutConstraint.activate([
+      dateStepper.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -10),
+      dateStepper.leadingAnchor.constraint(equalTo: titleLabel.trailingAnchor, constant: 10),
+      dateStepper.heightAnchor.constraint(equalTo: view.heightAnchor, multiplier: 0.1),
+      dateStepper.centerYAnchor.constraint(equalTo: titleLabel.centerYAnchor)
+    ])
+  }
+  
+  func configureBaseView() {
+    NSLayoutConstraint.activate([
+      baseView.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 10),
+      baseView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 10),
+      baseView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -10),
+      baseView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -20)
+    ])
+  }
+  
+  func configureCardCollectionView() {
+    NSLayoutConstraint.activate([
+      cardCollectionView.topAnchor.constraint(equalTo: baseView.topAnchor),
+      cardCollectionView.leadingAnchor.constraint(equalTo: baseView.leadingAnchor),
+      cardCollectionView.trailingAnchor.constraint(equalTo: baseView.trailingAnchor),
+      cardCollectionView.bottomAnchor.constraint(equalTo: segmentedControl.topAnchor)
+    ])
+  }
+  
+  func configureSegmentedControl() {
+    NSLayoutConstraint.activate([
+      segmentedControl.bottomAnchor.constraint(equalTo: baseView.bottomAnchor),
+      segmentedControl.leadingAnchor.constraint(equalTo: baseView.leadingAnchor),
+      segmentedControl.trailingAnchor.constraint(equalTo: baseView.trailingAnchor),
+      segmentedControl.heightAnchor.constraint(equalToConstant: 50),
+    ])
   }
 }
 

--- a/iOS/AreUDone/AreUDone/CalendarScene/View/Controller/CalendarViewController.swift
+++ b/iOS/AreUDone/AreUDone/CalendarScene/View/Controller/CalendarViewController.swift
@@ -23,54 +23,35 @@ final class CalendarViewController: UIViewController {
 
   private lazy var dataSource = configureDataSource()
 
-  private lazy var cardCollectionView: CardCollectionView = {
-    let flowLayout = UICollectionViewFlowLayout()
-    let collectionView = CardCollectionView(
-      frame: CGRect.zero,
-      collectionViewLayout: flowLayout
-    )
-    collectionView.translatesAutoresizingMaskIntoConstraints = false
-    
-    return collectionView
-  }()
+  @IBOutlet weak var cardCollectionView: CardCollectionView!
+
+  @IBOutlet weak var baseView: UIView! {
+    didSet {
+      baseView.backgroundColor = .clear
+      baseView.addShadow(
+        offset: .zero,
+        radius: 3,
+        opacity: 0.5
+      )
+    }
+  }
   
-  private lazy var baseView: UIView = {
-    let view = UIView()
-    view.translatesAutoresizingMaskIntoConstraints = false
-    view.backgroundColor = .clear
-    view.addShadow(
-      offset: .zero,
-      radius: 3,
-      opacity: 0.5
-    )
-    
-    return view
-  }()
+  @IBOutlet weak var titleLabel: UILabel! {
+    didSet {
+      titleLabel.font = UIFont.nanumB(size: 30)
+      titleLabel.text = "전체 카드"
+    }
+  }
+
+  @IBOutlet weak var dateStepper: DateStepper!
   
-  private lazy var titleLabel: UILabel = {
-    let label = UILabel()
-    label.translatesAutoresizingMaskIntoConstraints = false
-    label.font = UIFont.nanumB(size: 30)
-    label.text = "전체 카드"
-    
-    return label
-  }()
-  
-  private lazy var dateStepper: DateStepper = {
-    let dateStepper = DateStepper()
-    dateStepper.translatesAutoresizingMaskIntoConstraints = false
-    
-    return dateStepper
-  }()
-  
-  private lazy var segmentedControl: CustomSegmentedControl = {
-    let segmentedControl = CustomSegmentedControl()
-    segmentedControl.translatesAutoresizingMaskIntoConstraints = false
-    let titles = CardSegment.allCases.map { $0.text }
-    segmentedControl.setButtonTitles(buttonTitles: titles)
-    
-    return segmentedControl
-  }()
+  @IBOutlet private weak var segmentedControl: CustomSegmentedControl! {
+    didSet {
+      let titles = CardSegment.allCases.map { $0.text }
+      segmentedControl.setButtonTitles(buttonTitles: titles)
+    }
+  }
+
 
   
   // MARK: - Initializer
@@ -144,65 +125,6 @@ private extension CalendarViewController {
     
     dateStepper.delegate = self
     viewModel.initializeDate()
-    
-    configureView()
-    configureTitleLabel()
-    configureDateStepper()
-    configureBaseView()
-    configureCardCollectionView()
-    configureSegmentedControl()
-  }
-  
-  func configureView() {
-    view.addSubview(titleLabel)
-    view.addSubview(dateStepper)
-    view.addSubview(baseView)
-    baseView.addSubview(cardCollectionView)
-    baseView.addSubview(segmentedControl)
-  }
-  
-  func configureTitleLabel() {
-    NSLayoutConstraint.activate([
-      titleLabel.leadingAnchor.constraint(equalTo: baseView.leadingAnchor, constant: 10),
-      titleLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 20),
-      titleLabel.heightAnchor.constraint(equalTo: view.heightAnchor, multiplier: 0.06)
-    ])
-  }
-  
-  func configureDateStepper() {
-    NSLayoutConstraint.activate([
-      dateStepper.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -10),
-      dateStepper.leadingAnchor.constraint(equalTo: titleLabel.trailingAnchor, constant: 10),
-      dateStepper.heightAnchor.constraint(equalTo: view.heightAnchor, multiplier: 0.1),
-      dateStepper.centerYAnchor.constraint(equalTo: titleLabel.centerYAnchor)
-    ])
-  }
-  
-  func configureBaseView() {
-    NSLayoutConstraint.activate([
-      baseView.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 10),
-      baseView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 10),
-      baseView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -10),
-      baseView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -20)
-    ])
-  }
-  
-  func configureCardCollectionView() {
-    NSLayoutConstraint.activate([
-      cardCollectionView.topAnchor.constraint(equalTo: baseView.topAnchor),
-      cardCollectionView.leadingAnchor.constraint(equalTo: baseView.leadingAnchor),
-      cardCollectionView.trailingAnchor.constraint(equalTo: baseView.trailingAnchor),
-      cardCollectionView.bottomAnchor.constraint(equalTo: segmentedControl.topAnchor)
-    ])
-  }
-  
-  func configureSegmentedControl() {
-    NSLayoutConstraint.activate([
-      segmentedControl.bottomAnchor.constraint(equalTo: baseView.bottomAnchor),
-      segmentedControl.leadingAnchor.constraint(equalTo: baseView.leadingAnchor),
-      segmentedControl.trailingAnchor.constraint(equalTo: baseView.trailingAnchor),
-      segmentedControl.heightAnchor.constraint(equalToConstant: 50),
-    ])
   }
 }
 
@@ -213,6 +135,7 @@ private extension CalendarViewController {
   
   func bindUI() {
     bindingInitializeCardCollectionView()
+    bindingUpdateCardCollectionView()
     bindingUpdateDate()
   }
   
@@ -311,13 +234,24 @@ extension CalendarViewController: UICollectionViewDelegate {
 
 extension CalendarViewController: CustomSegmentedControlDelegate {
   
-  func change(to title: TitleChangeable) {
-    self.titleLabel.text = title.text
+  func change(to segmented: TitleChangeable) {
+    self.titleLabel.text = segmented.text
     UIView.transition(
       with: titleLabel,
       duration: 0.3,
       options: .transitionFlipFromLeft,
       animations: nil,
       completion: nil)
+    
+    switch segmented {
+    case CardSegment.allCard:
+      viewModel.fetchUpdateDailyCards(withOption: .allCard)
+      
+    case CardSegment.myCard:
+      viewModel.fetchUpdateDailyCards(withOption: .myCard)
+      
+    default:
+      return
+    }
   }
 }

--- a/iOS/AreUDone/AreUDone/CalendarScene/View/Controller/CalendarViewController.swift
+++ b/iOS/AreUDone/AreUDone/CalendarScene/View/Controller/CalendarViewController.swift
@@ -171,7 +171,10 @@ extension CalendarViewController: CardCellDelegate {
       guard let self = self else { return }
       var snapshot = self.dataSource.snapshot()
       snapshot.deleteItems([item])
-      self.dataSource.apply(snapshot)
+      
+      DispatchQueue.main.async {
+        self.dataSource.apply(snapshot)
+      }
     }
   }
   

--- a/iOS/AreUDone/AreUDone/CalendarScene/View/DateStepper.xib
+++ b/iOS/AreUDone/AreUDone/CalendarScene/View/DateStepper.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -23,11 +23,11 @@
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="iN0-l3-epB">
-            <rect key="frame" x="0.0" y="0.0" width="364" height="214"/>
+            <rect key="frame" x="0.0" y="0.0" width="260" height="69"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="chevron.left" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="bvN-B2-fCF">
-                    <rect key="frame" x="42" y="91.5" width="35" height="31.5"/>
+                    <rect key="frame" x="20" y="19" width="35" height="31.5"/>
                     <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="35" id="DwE-Ra-SNB"/>
@@ -35,7 +35,7 @@
                     </constraints>
                 </imageView>
                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="chevron.right" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="bKy-zl-PwM">
-                    <rect key="frame" x="287" y="91.5" width="35" height="31.5"/>
+                    <rect key="frame" x="205" y="19" width="35" height="31.5"/>
                     <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="35" id="ObO-9U-4XT"/>
@@ -43,7 +43,7 @@
                     </constraints>
                 </imageView>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2020.11.18" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8Ih-3b-dAA">
-                    <rect key="frame" x="117" y="91" width="130" height="32"/>
+                    <rect key="frame" x="65" y="20" width="130" height="29.5"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="130" id="Esj-oN-U9B"/>
                     </constraints>
@@ -59,11 +59,11 @@
                 <constraint firstItem="8Ih-3b-dAA" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" id="RUg-3f-8Ag"/>
                 <constraint firstItem="bKy-zl-PwM" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" id="pA2-hg-iek"/>
                 <constraint firstItem="8Ih-3b-dAA" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="t23-Rt-a5C"/>
-                <constraint firstItem="8Ih-3b-dAA" firstAttribute="leading" secondItem="bvN-B2-fCF" secondAttribute="trailing" constant="40" id="uQu-0f-5De"/>
-                <constraint firstItem="bKy-zl-PwM" firstAttribute="leading" secondItem="8Ih-3b-dAA" secondAttribute="trailing" constant="40" id="wYW-uy-Rij"/>
+                <constraint firstItem="8Ih-3b-dAA" firstAttribute="leading" secondItem="bvN-B2-fCF" secondAttribute="trailing" constant="10" id="uQu-0f-5De"/>
+                <constraint firstItem="bKy-zl-PwM" firstAttribute="leading" secondItem="8Ih-3b-dAA" secondAttribute="trailing" constant="10" id="wYW-uy-Rij"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <point key="canvasLocation" x="127.53623188405798" y="360.9375"/>
+            <point key="canvasLocation" x="202.89855072463769" y="409.48660714285711"/>
         </view>
     </objects>
     <resources>

--- a/iOS/AreUDone/AreUDone/CalendarScene/ViewModel/CalendarViewModel.swift
+++ b/iOS/AreUDone/AreUDone/CalendarScene/ViewModel/CalendarViewModel.swift
@@ -13,7 +13,6 @@ protocol CalendarViewModelProtocol {
   func bindingUpdateDate(handler: @escaping (String) -> Void)
   
   func fetchUpdateDailyCards(withOption option: FetchDailyCardsOption)
-  func initializeDate()
   func changeDate(to date: String, direction: Direction?)
   func deleteCard(for cardId: Int, completionHandler: @escaping () -> Void)
 }
@@ -53,10 +52,6 @@ final class CalendarViewModel: CalendarViewModelProtocol {
   
   
   // MARK:- Method
-  
-  func initializeDate() {
-    selectedDate = Date()
-  }
   
   func changeDate(to dateAsString: String, direction: Direction?) {
     guard

--- a/iOS/AreUDone/AreUDone/CalendarScene/ViewModel/CalendarViewModel.swift
+++ b/iOS/AreUDone/AreUDone/CalendarScene/ViewModel/CalendarViewModel.swift
@@ -18,6 +18,7 @@ protocol CalendarViewModelProtocol {
   
   func initializeDate()
   func changeDate(to date: String, direction: Direction?)
+  func deleteCard(for cardId: Int, completionHandler: @escaping () -> Void)
 }
 
 final class CalendarViewModel: CalendarViewModelProtocol {
@@ -59,6 +60,18 @@ final class CalendarViewModel: CalendarViewModelProtocol {
     let calendar = Calendar(identifier: .gregorian)
     if let updatedDate = calendar.date(byAdding: .day, value: value, to: date)?.toString() {
       updateDateHandler?(updatedDate)
+    }
+  }
+  
+  func deleteCard(for cardId: Int, completionHandler: @escaping () -> Void) {
+    cardService.deleteCard(for: cardId) { result in
+      switch result {
+      case .success(()):
+        completionHandler()
+        
+      case .failure(let error):
+        print(error)
+      }
     }
   }
   

--- a/iOS/AreUDone/AreUDone/CalendarScene/ViewModel/CalendarViewModel.swift
+++ b/iOS/AreUDone/AreUDone/CalendarScene/ViewModel/CalendarViewModel.swift
@@ -14,11 +14,18 @@ protocol CalendarViewModelProtocol {
   func bindingUpdateDate(handler: @escaping (String) -> Void)
   
   func fetchInitializeDailyCards()
-  func fetchUpdateDailyCards()
+  func fetchUpdateDailyCards(withOption option: FetchDailyCardsOption)
   
   func initializeDate()
   func changeDate(to date: String, direction: Direction?)
   func deleteCard(for cardId: Int, completionHandler: @escaping () -> Void)
+}
+
+extension CalendarViewModelProtocol {
+  
+  func fetchUpdateDailyCards(withOption option: FetchDailyCardsOption = .allCard) {
+    fetchUpdateDailyCards(withOption: option)
+  }
 }
 
 final class CalendarViewModel: CalendarViewModelProtocol {
@@ -75,8 +82,16 @@ final class CalendarViewModel: CalendarViewModelProtocol {
     }
   }
   
-  private func fetchDailyCards(with handler: ((Cards) -> Void)?) {
-    cardService.fetchDailyCards(dateString: Date().toString()) { result in
+  func fetchInitializeDailyCards() {
+    fetchDailyCards(with: initializeCardTableViewHandler)
+  }
+  
+  func fetchUpdateDailyCards(withOption option: FetchDailyCardsOption = .allCard) {
+    fetchDailyCards(with: updateCardTableViewHandler, option: option)
+  }
+  
+  private func fetchDailyCards(with handler: ((Cards) -> Void)?, option: FetchDailyCardsOption = .allCard) {
+    cardService.fetchDailyCards(dateString: Date().toString(), option: option) { result in
       switch result {
       case .success(let cards):
         //TODO: - self가 순환참조를 일으키는 확인해야 함.
@@ -99,14 +114,6 @@ extension CalendarViewModel {
   
   func bindingUpdateCardCollectionView(handler: @escaping (Cards) -> Void) {
     updateCardTableViewHandler = handler
-  }
-  
-  func fetchInitializeDailyCards() {
-    fetchDailyCards(with: initializeCardTableViewHandler)
-  }
-  
-  func fetchUpdateDailyCards() {
-    fetchDailyCards(with: updateCardTableViewHandler)
   }
   
   func bindingUpdateDate(handler: @escaping (String) -> Void) {

--- a/iOS/AreUDone/AreUDone/CardDetailScene/CardDetailCoordinator.swift
+++ b/iOS/AreUDone/AreUDone/CardDetailScene/CardDetailCoordinator.swift
@@ -38,10 +38,10 @@ final class CardDetailCoordinator: NavigationCoordinator {
             identifier: CardDetailViewController.identifier,
             creator: { [weak self] coder in
               guard let self = self else { return UIViewController() }
-              let cardService = CardService(router: MockRouter(jsonFactory: CardTrueJsonFactory()))
+              let cardService = CardService(router: self.router)
               let imageService = ImageService(router: self.router)
-              let userService = UserService(router: MockRouter(jsonFactory: UserJsonFactory()))
-              let commentService = CommentService(router: MockRouter(jsonFactory: CardTrueJsonFactory()))
+              let userService = UserService(router: self.router)
+              let commentService = CommentService(router: self.router)
               let viewModel = CardDetailViewModel(
                 id: self.id,
                 cardService: cardService,

--- a/iOS/AreUDone/AreUDone/Common/Constants/FetchDailyCardsOption.swift
+++ b/iOS/AreUDone/AreUDone/Common/Constants/FetchDailyCardsOption.swift
@@ -1,0 +1,23 @@
+//
+//  FetchDailyCardsOption.swift
+//  AreUDone
+//
+//  Created by 서명렬 on 2020/12/10.
+//
+
+import Foundation
+
+enum FetchDailyCardsOption {
+  case allCard
+  case myCard
+  
+  var value: String? {
+    switch self {
+    case .myCard:
+      return "me"
+      
+    default:
+      return nil
+    }
+  }
+}

--- a/iOS/AreUDone/AreUDone/Common/Constants/TitleChangeable.swift
+++ b/iOS/AreUDone/AreUDone/Common/Constants/TitleChangeable.swift
@@ -1,0 +1,43 @@
+//
+//  TitleChangeable.swift
+//  AreUDone
+//
+//  Created by 서명렬 on 2020/12/10.
+//
+
+import Foundation
+
+protocol TitleChangeable {
+  
+  var text: String { get }
+}
+
+enum CardSegment: CaseIterable, TitleChangeable {
+  case allCard
+  case myCard
+  
+  var text: String {
+    switch self {
+    case .allCard:
+      return "전체 카드"
+      
+    case .myCard:
+      return "나의 카드"
+    }
+  }
+}
+
+enum BoardSegment: CaseIterable, TitleChangeable {
+  case myBoard
+  case invitedBoard
+  
+  var text: String {
+    switch self {
+    case .myBoard:
+      return "나의 보드"
+      
+    case .invitedBoard:
+      return "공유 보드"
+    }
+  }
+}

--- a/iOS/AreUDone/AreUDone/Common/View/CustomSegmentControl.swift
+++ b/iOS/AreUDone/AreUDone/Common/View/CustomSegmentControl.swift
@@ -9,7 +9,7 @@ import UIKit
 
 protocol CustomSegmentedControlDelegate: AnyObject {
   
-  func change(to title: String)
+  func change(to title: TitleChangeable)
 }
 
 final class CustomSegmentedControl: UIView {
@@ -142,7 +142,18 @@ private extension CustomSegmentedControl {
       let selectorWidth = frame.width / CGFloat(buttonTitles.count)
       let selectorPosition = selectorWidth * CGFloat(index)
       selectedIndex = index
-      delegate?.change(to: buttonTitles[selectedIndex])
+      
+      switch delegate {
+      case is CalendarViewController:
+        delegate?.change(to: CardSegment.allCases[selectedIndex])
+        
+      case is BoardListViewController:
+        delegate?.change(to: BoardSegment.allCases[selectedIndex])
+        
+      default:
+        return
+      }
+      
       
       UIViewPropertyAnimator(duration: 0.15, curve: .easeInOut) {
         self.selectorView.frame.origin.x = selectorPosition + selectorWidth * (self.widthRate/2)

--- a/iOS/AreUDone/AreUDone/Common/View/CustomSegmentControl.swift
+++ b/iOS/AreUDone/AreUDone/Common/View/CustomSegmentControl.swift
@@ -72,6 +72,17 @@ private extension CustomSegmentedControl {
   }
   
   func configureView() {
+    layer.cornerRadius = 10
+    layer.maskedCorners = [
+      .layerMinXMaxYCorner,
+      .layerMaxXMaxYCorner
+    ]
+    addShadow(
+      offset: CGSize(width: 0, height: -1),
+      radius: 2,
+      opacity: 0.5
+    )
+    
     backgroundColor = UIColor.white
   }
   

--- a/iOS/AreUDone/AreUDone/Common/View/CustomSegmentControl.swift
+++ b/iOS/AreUDone/AreUDone/Common/View/CustomSegmentControl.swift
@@ -9,7 +9,7 @@ import UIKit
 
 protocol CustomSegmentedControlDelegate: AnyObject {
   
-  func change(to title: TitleChangeable)
+  func change(to segmented: TitleChangeable)
 }
 
 final class CustomSegmentedControl: UIView {
@@ -67,8 +67,9 @@ private extension CustomSegmentedControl {
   func configure() {
     configureView()
     configureButton()
-    configureSelectorView()
+    
     configStackView()
+    configureSelectorView()
   }
   
   func configureView() {
@@ -103,14 +104,17 @@ private extension CustomSegmentedControl {
   }
   
   private func configureSelectorView() {
-    let selectorWidth = frame.width / CGFloat(buttonTitles.count)
+    layoutIfNeeded()
+    let padding: CGFloat = 10
+    let selectorWidth = (UIScreen.main.bounds.width - padding * 2) / CGFloat(buttonTitles.count)
     
     selectorView = UIView(
       frame: CGRect(
-        x: selectorWidth * (widthRate/2),
+        x: selectorWidth * widthRate - (selectorWidth * widthRate / 2),
         y: frame.height * heightRate,
         width: selectorWidth * widthRate,
-        height: 2)
+        height: 2
+      )
     )
     selectorView.backgroundColor = selectorViewColor
     addSubview(selectorView)
@@ -156,7 +160,7 @@ private extension CustomSegmentedControl {
       
       
       UIViewPropertyAnimator(duration: 0.15, curve: .easeInOut) {
-        self.selectorView.frame.origin.x = selectorPosition + selectorWidth * (self.widthRate/2)
+        self.selectorView.frame.origin.x = selectorPosition + selectorWidth * (self.widthRate) - (selectorWidth * self.widthRate / 2)
       }.startAnimation()
       
       button.setTitleColor(selectorTextColor, for: .normal)

--- a/iOS/AreUDone/AreUDone/MemberUpdateScene/MemberUpdateCoordinator.swift
+++ b/iOS/AreUDone/AreUDone/MemberUpdateScene/MemberUpdateCoordinator.swift
@@ -39,8 +39,8 @@ final class MemberUpdateCoordinator: NavigationCoordinator {
             identifier: MemberUpdateViewController.identifier,
             creator: { [weak self] coder in
               guard let self = self else { return UIViewController() }
-              let cardService = CardService(router: MockRouter(jsonFactory: CardTrueJsonFactory()))
-              let boardService = BoardService(router: MockRouter(jsonFactory: BoardDetailTrueJsonFactory()))
+              let cardService = CardService(router: self.router)
+              let boardService = BoardService(router: self.router)
               let imageService = ImageService(router: self.router)
               let viewModel = MemberUpdateViewModel(
                 cardId: self.cardId,

--- a/iOS/AreUDone/AreUDone/Service/CardService/CardEndPoint.swift
+++ b/iOS/AreUDone/AreUDone/Service/CardService/CardEndPoint.swift
@@ -75,7 +75,7 @@ extension CardEndPoint: EndPointable {
       return nil
       
     case .fetchCardsCount(let startDate, let endDate):
-      return ["q": "startdate:\(startDate) enddate\(endDate)"]
+      return ["q": "startdate:\(startDate) enddate:\(endDate) member:me"]
       
     case .deleteCard:
       return nil

--- a/iOS/AreUDone/AreUDone/Service/CardService/CardEndPoint.swift
+++ b/iOS/AreUDone/AreUDone/Service/CardService/CardEndPoint.swift
@@ -23,6 +23,7 @@ enum CardEndPoint {
        )
   case updateCardMember(id: Int, userIds: [Int])
   case fetchCardsCount(startDate: String, endDate: String, member: String?)
+  case deleteCard(id: Int)
 }
 
 extension CardEndPoint: EndPointable {
@@ -42,6 +43,9 @@ extension CardEndPoint: EndPointable {
       
     case .fetchCardsCount:
       return "\(APICredentials.ip)/api/card/count"
+      
+    case .deleteCard(let id):
+      return "\(APICredentials.ip)/api/card/\(id)"
     }
   }
   
@@ -70,6 +74,9 @@ extension CardEndPoint: EndPointable {
         value += " " + member
       }
       return ["q": value]
+      
+    case .deleteCard:
+      return nil
     }
   }
   
@@ -89,6 +96,9 @@ extension CardEndPoint: EndPointable {
       
     case .fetchCardsCount:
       return .get
+      
+    case .deleteCard:
+      return .delete
     }
   }
   

--- a/iOS/AreUDone/AreUDone/Service/CardService/CardEndPoint.swift
+++ b/iOS/AreUDone/AreUDone/Service/CardService/CardEndPoint.swift
@@ -11,7 +11,7 @@ import KeychainFramework
 
 enum CardEndPoint {
   
-  case fetchDailyCards(dateString: String)
+  case fetchDailyCards(dateString: String, option: FetchDailyCardsOption = .allCard)
   case fetchDetailCard(id: Int)
   case updateCard(
         id: Int,
@@ -22,7 +22,7 @@ enum CardEndPoint {
         dueDate: String?
        )
   case updateCardMember(id: Int, userIds: [Int])
-  case fetchCardsCount(startDate: String, endDate: String, member: String?)
+  case fetchCardsCount(startDate: String, endDate: String)
   case deleteCard(id: Int)
 }
 
@@ -56,8 +56,14 @@ extension CardEndPoint: EndPointable {
   
   var query: HTTPQuery? {
     switch self {
-    case .fetchDailyCards(let dateString): // ?q=date:2020-01-01
-      return ["q": "date:\(dateString)"]
+    case .fetchDailyCards(let dateString, let option): // ?q=date:2020-01-01 member:me
+      var value = "date:\(dateString)"
+      
+      if let optionValue = option.value {
+        value += " member:\(optionValue)"
+      }
+      
+      return ["q": value]
       
     case .fetchDetailCard:
       return nil
@@ -68,12 +74,8 @@ extension CardEndPoint: EndPointable {
     case .updateCardMember:
       return nil
       
-    case .fetchCardsCount(let startDate, let endDate, let member):
-      var value = "startdate:" + startDate + " " + "enddate:" + endDate
-      if let member = member {
-        value += " " + member
-      }
-      return ["q": value]
+    case .fetchCardsCount(let startDate, let endDate):
+      return ["q": "startdate:\(startDate) enddate\(endDate)"]
       
     case .deleteCard:
       return nil

--- a/iOS/AreUDone/AreUDone/Service/CardService/CardEndPoint.swift
+++ b/iOS/AreUDone/AreUDone/Service/CardService/CardEndPoint.swift
@@ -110,7 +110,7 @@ extension CardEndPoint: EndPointable {
     
     return [
       "Authorization": "\(accessToken)",
-      "Content-Type": "application/json",
+      "Content-Type": "application/x-www-form-urlencoded",
       "Accept": "application/json"
     ]
   }

--- a/iOS/AreUDone/AreUDone/Service/CardService/CardService.swift
+++ b/iOS/AreUDone/AreUDone/Service/CardService/CardService.swift
@@ -27,6 +27,7 @@ protocol CardServiceProtocol {
     member: String?,
     completionHandler: @escaping ((Result<MonthCardCount, APIError>) -> Void)
   )
+  func deleteCard(for cardId: Int, completionHandler: @escaping ((Result<Void, APIError>) -> Void))
 }
 
 extension CardServiceProtocol {
@@ -117,6 +118,12 @@ class CardService: CardServiceProtocol {
       endDate: endDate,
       member: member
     )) { (result: Result<MonthCardCount, APIError>) in
+      completionHandler(result)
+    }
+  }
+  
+  func deleteCard(for cardId: Int, completionHandler: @escaping ((Result<Void, APIError>) -> Void)) {
+    router.request(route: CardEndPoint.deleteCard(id: cardId)) { (result: Result<Void, APIError>) in
       completionHandler(result)
     }
   }

--- a/iOS/AreUDone/AreUDone/Service/CardService/CardService.swift
+++ b/iOS/AreUDone/AreUDone/Service/CardService/CardService.swift
@@ -9,7 +9,7 @@ import Foundation
 import NetworkFramework
 
 protocol CardServiceProtocol {
-  func fetchDailyCards(dateString: String, completionHandler: @escaping (Result<Cards, APIError>) -> Void)
+  func fetchDailyCards(dateString: String, option: FetchDailyCardsOption, completionHandler: @escaping (Result<Cards, APIError>) -> Void)
   func fetchDetailCard(id: Int, completionHandler: @escaping ((Result<CardDetail, APIError>) -> Void))
   func updateCard(
     id: Int,
@@ -24,7 +24,6 @@ protocol CardServiceProtocol {
   func fetchCardsCount(
     startDate: String,
     endDate: String,
-    member: String?,
     completionHandler: @escaping ((Result<MonthCardCount, APIError>) -> Void)
   )
   func deleteCard(for cardId: Int, completionHandler: @escaping ((Result<Void, APIError>) -> Void))
@@ -68,8 +67,8 @@ class CardService: CardServiceProtocol {
   
   // MARK: - Method
   
-  func fetchDailyCards(dateString: String, completionHandler: @escaping (Result<Cards, APIError>) -> Void) {
-    router.request(route: CardEndPoint.fetchDailyCards(dateString: dateString)) { (result: Result<Cards, APIError>) in
+  func fetchDailyCards(dateString: String, option: FetchDailyCardsOption, completionHandler: @escaping (Result<Cards, APIError>) -> Void) {
+    router.request(route: CardEndPoint.fetchDailyCards(dateString: dateString, option: option)) { (result: Result<Cards, APIError>) in
       completionHandler(result)
     }
   }
@@ -110,13 +109,11 @@ class CardService: CardServiceProtocol {
   func fetchCardsCount(
     startDate: String,
     endDate: String,
-    member: String?,
     completionHandler: @escaping ((Result<MonthCardCount, APIError>) -> Void)
   ) {
     router.request(route: CardEndPoint.fetchCardsCount(
       startDate: startDate,
-      endDate: endDate,
-      member: member
+      endDate: endDate
     )) { (result: Result<MonthCardCount, APIError>) in
       completionHandler(result)
     }

--- a/iOS/AreUDone/AreUDone/Service/CommentService/CommentEndPoint.swift
+++ b/iOS/AreUDone/AreUDone/Service/CommentService/CommentEndPoint.swift
@@ -51,7 +51,7 @@ extension CommentEndPoint: EndPointable {
     
     return [
       "Authorization": "\(accessToken)",
-      "Content-Type": "application/json",
+      "Content-Type": "application/x-www-form-urlencoded",
       "Accept": "application/json"
     ]
   }


### PR DESCRIPTION
# Calendar화면에서 모든 카드와 내가 즐겨찾는 카드로 분리하여 표시

## 📎 해당 이슈
#252 #258 

## 🛠 구현 내용 

- Calendar 화면 전체적인 UI 수정
- 전체 카드와 나의카드를 분리해서 볼 수 있도록 수정
- 날짜를 이동했을 경우 데이터를 가져올 수 있도록 API 연동
- Calendar ViewModel 리팩토링

## 🙋‍ 리뷰어 참고 사항 
코드가 길어졌습니다...
ViewModel을 리팩토링 했는데 리뷰 부탁드립니다!