### PR TITLE
보드 상세 조회 리스트 position 순서 문제 수정

### DIFF
--- a/server/src/service/BoardService.js
+++ b/server/src/service/BoardService.js
@@ -85,6 +85,8 @@ export class BoardService extends BaseService {
             ])
             .loadRelationCountAndMap('cards.commentCount', 'cards.comments')
             .where('board.id = :id', { id: boardId })
+            .orderBy('lists.position', 'ASC')
+            .addOrderBy('cards.position', 'ASC')
             .getOne();
         if (Array.isArray(boardDetail?.invitations)) {
             boardDetail.invitedUsers = boardDetail.invitations.map((v) => v.user);


### PR DESCRIPTION
# 보드 상세 조회 리스트 position 순서 문제 수정

## 📎 해당 이슈

이슈 링크 (#234 )

## 🛠 구현 내용 

- order by를 사용하여 보드 상세 조회 리스트 position 오름차순으로 정렬
- list의 카드들도 position 오름차순으로 정렬

## 🙋‍ 리뷰어 참고 사항 

또 순서가 중요한 API가 있을까요?
