### PR TITLE
일별 카드 개수 조회 API 오류 수정

### DIFF
--- a/server/src/dao/CustomCardRepository.js
+++ b/server/src/dao/CustomCardRepository.js
@@ -53,8 +53,7 @@ export class CustomCardRepository extends BaseRepository {
             .addSelect('count(1)', 'count')
             .leftJoin('card.members', 'member')
             .where(`card.due_date BETWEEN :startDate AND :endDate`, { startDate, endDate })
-            .andWhere('card.creator_id=:userId', { userId })
-            .orWhere('member.user_id=:userId', { userId })
+            .andWhere('(card.creator_id=:userId OR member.user_id=:userId)', { userId })
             .groupBy(`date_format(card.due_date, '%Y-%m-%d')`)
             .getRawMany();
 


### PR DESCRIPTION
# 일별 카드 개수 조회 API 오류 수정

## 📎 해당 이슈

이슈 링크 (#270 )

## 🛠 구현 내용 

- 일별 카드 개수 조회 API 오류 수정
- 오류가 났던 상황에 대한 테스트 코드로 변경

## 🙋‍ 리뷰어 참고 사항 

