### PR TITLE
리스트/카드 포지션 변경 로직 적용

### DIFF
--- a/iOS/AreUDone/AreUDone/BoardDetailScene/BoardDetailCoordinator.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/BoardDetailCoordinator.swift
@@ -111,8 +111,8 @@ extension BoardDetailCoordinator {
     navigationController?.pushViewController(cardDetailViewController, animated: true)
   }
   
-  func presentCardAdd(ofListId listId: Int) {
-    cardAddCoordinator = CardAddCoordinator(router: router, listId: listId)
+  func presentCardAdd(to viewModel: ListViewModelProtocol) {
+    cardAddCoordinator = CardAddCoordinator(router: router, viewModel: viewModel)
     
     let viewController = cardAddCoordinator.start()
     let subNavigationController = UINavigationController()

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/View/CollectionView/BoardDetailCollectionViewCell.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/View/CollectionView/BoardDetailCollectionViewCell.swift
@@ -55,8 +55,20 @@ final class BoardDetailCollectionViewCell: UICollectionViewCell, Reusable {
     self.viewModel = viewModel
     self.dataSource = dataSource
     collectionView.dataSource = dataSource
-    
-    collectionView.reloadData()
+
+    bindUI()
+    viewModel.updateCollectionView()
+  }
+}
+
+private extension BoardDetailCollectionViewCell {
+  
+  func bindUI() {
+    viewModel.bindingUpdateCollectionView { [weak self] in
+      DispatchQueue.main.async {
+        self?.collectionView.reloadData()
+      }
+    }
   }
 }
 

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/View/CollectionView/BoardDetailCollectionViewCell.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/View/CollectionView/BoardDetailCollectionViewCell.swift
@@ -45,9 +45,9 @@ final class BoardDetailCollectionViewCell: UICollectionViewCell, Reusable {
     
     collectionView.reloadData()
   }
- 
+  
   // MARK: - Method
-
+  
   func update(
     with viewModel: ListViewModelProtocol,
     dataSource: UICollectionViewDataSource
@@ -55,7 +55,7 @@ final class BoardDetailCollectionViewCell: UICollectionViewCell, Reusable {
     self.viewModel = viewModel
     self.dataSource = dataSource
     collectionView.dataSource = dataSource
-
+    
     bindUI()
     viewModel.updateCollectionView()
   }
@@ -79,7 +79,7 @@ private extension BoardDetailCollectionViewCell {
   
   func configure() {
     addSubview(collectionView)
-
+    
     configureCollectionView()
     configureNotification()
   }
@@ -145,7 +145,7 @@ extension BoardDetailCollectionViewCell: UICollectionViewDropDelegate {
   
   // 2. 드래깅 중
   func collectionView(_ collectionView: UICollectionView, dropSessionDidUpdate session: UIDropSession, withDestinationIndexPath destinationIndexPath: IndexPath?) -> UICollectionViewDropProposal {
-    return UICollectionViewDropProposal(operation: .copy, intent: .insertAtDestinationIndexPath)
+    return UICollectionViewDropProposal(operation: .move, intent: .insertAtDestinationIndexPath)
   }
   
   // 3. 드래깅 끝
@@ -165,77 +165,67 @@ extension BoardDetailCollectionViewCell: UICollectionViewDropDelegate {
       
       let source = coordinator.items.first?.sourceIndexPath
       let destination = coordinator.destinationIndexPath
-            
+      
       switch (source, destination) {
       ///  ** 1. 같은 컬렉션뷰**
       case (.some(let sourceIndexPath), .some(let destinationIndexPath)):
-        changeData(inSame: collectionView, about: card, by: sourceIndexPath, and: destinationIndexPath)
-                
-      /// **2. 다른 컬렉션뷰: cell 이 있는 테이블뷰에 삽입할 때(insert)**
-      case (nil, .some(let destinationIndexPath)):
-        let localContext = coordinator.session.localDragSession?.localContext
         
-        insertData(with: localContext) {
-          viewModel.insert(card: card, at: destinationIndexPath.item)
-          
-          let item = destinationIndexPath.item
-          collectionView.insertItems(at: [IndexPath(item: item, section: 0)])
+        viewModel.updateCardPosition(from: sourceIndexPath.item, to: destinationIndexPath.item, by: card) {
+          DispatchQueue.main.async {
+            collectionView.performBatchUpdates {
+              collectionView.deleteItems(at: [IndexPath(item: sourceIndexPath.item, section: 0)])
+              collectionView.insertItems(at: [IndexPath(item: destinationIndexPath.item, section: 0)])
+            }
+          }
         }
-                
-      /// **3. 다른 컬렉션뷰: cell 이 없는 컬렉션뷰에 삽입할 때(append)**
+        
+      /// **2. 다른 컬렉션뷰: cell 을 밀어내고 삽입할 때**
+      case (nil, .some(let destinationIndexPath)):
+        guard let (
+                sourceViewModel,
+                sourceIndexPath,
+                sourceCollectionView) = coordinator.session.localDragSession?.localContext
+                as? (
+                  ListViewModelProtocol,
+                  IndexPath,
+                  UICollectionView
+                ) else { return }
+        
+        viewModel.updateCardPosition(from: sourceIndexPath.item, to: destinationIndexPath.item, by: card, in: sourceViewModel) {
+          DispatchQueue.main.async {
+            sourceCollectionView.deleteItems(at: [IndexPath(item: sourceIndexPath.item, section: 0)])
+            
+            let index = destinationIndexPath.item
+            collectionView.insertItems(at: [IndexPath(item: index, section: 0)])
+          }
+        }
+        
+      /// **3. 다른 컬렉션뷰: cell 을 밀어내지 않고 삽입할 때**
       case (.some(_), nil):
         fallthrough
-      case (nil, nil):
-        let localContext = coordinator.session.localDragSession?.localContext
         
-        insertData(with: localContext) {
-          viewModel.append(card: card)
-          
-          let item = viewModel.numberOfCards()-1
-          collectionView.insertItems(at: [IndexPath(item: item, section: 0)])
+      case (nil, nil):
+        guard let (
+                sourceViewModel,
+                sourceIndexPath,
+                sourceCollectionView) = coordinator.session.localDragSession?.localContext
+                as? (
+                  ListViewModelProtocol,
+                  IndexPath,
+                  UICollectionView
+                ) else { return }
+        
+        viewModel.updateCardPosition(from: sourceIndexPath.item, by: card, in: sourceViewModel) { lastIndex in
+          DispatchQueue.main.async {
+            sourceCollectionView.deleteItems(at: [IndexPath(item: sourceIndexPath.item, section: 0)])
+            
+            collectionView.insertItems(at: [IndexPath(item: lastIndex, section: 0)])
+          }
         }
+        
+        break
       }
     }
-  }
-  
-  private func changeData(
-    inSame collectionView: UICollectionView,
-    about card: Card,
-    by sourceIndexPath: IndexPath,
-    and destinationIndexPath: IndexPath
-  ) {
-    let updatedIndexPaths = viewModel.makeUpdatedIndexPaths(by: sourceIndexPath, and: destinationIndexPath)
-    
-    viewModel.removeCard(at: sourceIndexPath.item)
-    viewModel.insert(card: card, at: destinationIndexPath.item)
-    
-    collectionView.reloadItems(at: updatedIndexPaths)
-  }
-  
-  private func insertData(
-    with localContext: Any?,
-    _ insertDestinationTableViewDataHandler: () -> Void
-  ) {
-    removeSourceTableViewData(localContext: localContext)
-    
-    insertDestinationTableViewDataHandler()
-  }
-  
-  private func removeSourceTableViewData(localContext: Any?) {
-    guard let (
-            sourceViewModel,
-            sourceIndexPath,
-            collectionView) = localContext
-            as? (
-              ListViewModelProtocol,
-              IndexPath,
-              UICollectionView
-            ) else { return }
-    
-    sourceViewModel.removeCard(at: sourceIndexPath.item)
-    // sourceViewModel 로부터 카드 id 얻어온 다음 list, position 정보 서버로 전송
-    
-    collectionView.reloadSections(IndexSet(integer: 0))
   }
 }
 

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/View/CollectionView/BoardDetailCollectionViewDataSource.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/View/CollectionView/BoardDetailCollectionViewDataSource.swift
@@ -13,12 +13,12 @@ final class BoardDetailCollectionViewDataSource: NSObject, UICollectionViewDataS
   // MARK: - Property
   
   private let viewModel: BoardDetailViewModelProtocol
-  private var presentCardAddHandler: ((Int) -> Void)?
+  private var presentCardAddHandler: ((ListViewModelProtocol) -> Void)?
   
   
   // MARK: - Initializer
   
-  init(viewModel: BoardDetailViewModelProtocol, presentCardAddHandler: ((Int) -> Void)? = nil) {
+  init(viewModel: BoardDetailViewModelProtocol, presentCardAddHandler: ((ListViewModelProtocol) -> Void)? = nil) {
     self.viewModel = viewModel
     self.presentCardAddHandler = presentCardAddHandler
     
@@ -35,7 +35,6 @@ final class BoardDetailCollectionViewDataSource: NSObject, UICollectionViewDataS
   func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
     let cell: BoardDetailCollectionViewCell = collectionView.dequeueReusableCell(forIndexPath: indexPath)
     
-    // TODO: 카드 id 가 있는 핸들러(카드상세화면), 리스트 id 가 있는 핸들러(카드 추가 화면)
     viewModel.fetchListViewModel(at: indexPath.item) { viewModel in
       let dataSource = ListCollectionViewDataSource(viewModel: viewModel, presentCardAddHandler: presentCardAddHandler)
       cell.update(with: viewModel, dataSource: dataSource)
@@ -47,7 +46,7 @@ final class BoardDetailCollectionViewDataSource: NSObject, UICollectionViewDataS
   func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
     let footerView: BoardDetailFooterView = collectionView.dequeReusableFooterView(forIndexPath: indexPath)
     
-    footerView.addHandler = { [weak self] title in
+    footerView.listAddHandler = { [weak self] title in
       self?.viewModel.createList(with: title)
     }
     return footerView

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/View/CollectionView/BoardDetailFooterView.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/View/CollectionView/BoardDetailFooterView.swift
@@ -32,7 +32,7 @@ final class BoardDetailFooterView: UICollectionReusableView, Reusable {
 
     return view
   }()
-  var addHandler: ((String) -> Void)?
+  var listAddHandler: ((String) -> Void)?
   
   
   // MARK: - Initializer
@@ -107,7 +107,7 @@ private extension BoardDetailFooterView {
 extension BoardDetailFooterView: AddOrCancelViewDelegate {
   
   func addButtonTapped(listTitle: String) {
-    addHandler?(listTitle)
+    listAddHandler?(listTitle)
     cancelButtonTapped()
   }
   

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/View/CollectionView/ListCollectionViewDataSource.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/View/CollectionView/ListCollectionViewDataSource.swift
@@ -13,12 +13,12 @@ final class ListCollectionViewDataSource: NSObject, UICollectionViewDataSource {
   // MARK: - Property
   
   private let viewModel: ListViewModelProtocol
-  private var presentCardAddHandler: ((Int) -> Void)?
+  private var presentCardAddHandler: ((ListViewModelProtocol) -> Void)?
   
   
   // MARK: - Initializer
   
-  init(viewModel: ListViewModelProtocol, presentCardAddHandler: ((Int) -> Void)?) {
+  init(viewModel: ListViewModelProtocol, presentCardAddHandler: ((ListViewModelProtocol) -> Void)?) {
     self.viewModel = viewModel
     self.presentCardAddHandler = presentCardAddHandler
 
@@ -50,8 +50,6 @@ final class ListCollectionViewDataSource: NSObject, UICollectionViewDataSource {
       return headerView
       
     case UICollectionView.elementKindSectionFooter:
-      // TODO: 여기서 카드 추가화면 띄우는 로직 필요
-      // viewmodel.createCard(리스트id) 핸들러? footerview에게 넘겨주기
       let footerView: ListFooterView = collectionView.dequeReusableFooterView(forIndexPath: indexPath)
       footerView.delegate = self
       
@@ -69,7 +67,6 @@ final class ListCollectionViewDataSource: NSObject, UICollectionViewDataSource {
 extension ListCollectionViewDataSource: ListFooterViewDelegate {
   
   func baseViewTapped() {
-    let listId = viewModel.fetchListId()
-    presentCardAddHandler?(listId)
+    presentCardAddHandler?(viewModel)
   }
 }

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/View/Controller/BoardDetailViewController.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/View/Controller/BoardDetailViewController.swift
@@ -14,8 +14,8 @@ final class BoardDetailViewController: UIViewController {
   
   private let viewModel: BoardDetailViewModelProtocol
   weak var coordinator: BoardDetailCoordinator?
-  private lazy var dataSource = BoardDetailCollectionViewDataSource(viewModel: viewModel) { [weak self] listId in
-    self?.coordinator?.presentCardAdd(ofListId: listId)
+  private lazy var dataSource = BoardDetailCollectionViewDataSource(viewModel: viewModel) { [weak self] viewModel in
+    self?.coordinator?.presentCardAdd(to: viewModel)
   }
   
   private lazy var titleTextField: UITextField = {
@@ -75,7 +75,7 @@ final class BoardDetailViewController: UIViewController {
     bindUI()
     configure()
     
-    viewModel.updateBoardDetailCollectionView()
+    viewModel.fetchBoardDetail()
   }
   
   override func viewDidAppear(_ animated: Bool) {

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/View/Controller/BoardDetailViewController.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/View/Controller/BoardDetailViewController.swift
@@ -286,22 +286,24 @@ extension BoardDetailViewController: UICollectionViewDropDelegate {
             let destination = coordinator.destinationIndexPath
       else { return }
      
-      viewModel.updatePosition(of: source.item, to: destination.item)
-
-      changeData(inSame: collectionView, about: list, by: source, and: destination)
+      viewModel.updatePosition(of: source.item, to: destination.item) { position in
+        DispatchQueue.main.async {
+          changeData(inSame: collectionView, about: list, to: position, of: source, and: destination)
+        }
+      }
     }
   }
   
   private func changeData(
     inSame collectionView: UICollectionView,
     about list: List,
-    by sourceIndexPath: IndexPath,
+    to position: Double,
+    of sourceIndexPath: IndexPath,
     and destinationIndexPath: IndexPath
   ) {
-    
-    // TODO: API 연동해보고 success 후 로컬 변경 or 로컬 변경 우선 선택
     let updatedIndexPaths = viewModel.makeUpdatedIndexPaths(by: sourceIndexPath, and: destinationIndexPath)
-    
+
+    list.position = position
     viewModel.remove(at: sourceIndexPath.row)
     viewModel.insert(list: list, at: destinationIndexPath.row)
     

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/View/Controller/BoardDetailViewController.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/View/Controller/BoardDetailViewController.swift
@@ -286,28 +286,17 @@ extension BoardDetailViewController: UICollectionViewDropDelegate {
             let destination = coordinator.destinationIndexPath
       else { return }
      
-      viewModel.updatePosition(of: source.item, to: destination.item) { position in
+      viewModel.updatePosition(of: source.item, to: destination.item, list: list) {
         DispatchQueue.main.async {
-          changeData(inSame: collectionView, about: list, to: position, of: source, and: destination)
+            DispatchQueue.main.async {
+              collectionView.performBatchUpdates {
+                collectionView.deleteItems(at: [IndexPath(item: source.item, section: 0)])
+                collectionView.insertItems(at: [IndexPath(item: destination.item, section: 0)])
+              }
+            }
         }
       }
     }
-  }
-  
-  private func changeData(
-    inSame collectionView: UICollectionView,
-    about list: List,
-    to position: Double,
-    of sourceIndexPath: IndexPath,
-    and destinationIndexPath: IndexPath
-  ) {
-    let updatedIndexPaths = viewModel.makeUpdatedIndexPaths(by: sourceIndexPath, and: destinationIndexPath)
-
-    list.position = position
-    viewModel.remove(at: sourceIndexPath.row)
-    viewModel.insert(list: list, at: destinationIndexPath.row)
-    
-    collectionView.reloadItems(at: updatedIndexPaths)
   }
 }
 

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/ViewModel/BoardDetailViewModel.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/ViewModel/BoardDetailViewModel.swift
@@ -21,7 +21,7 @@ protocol BoardDetailViewModelProtocol {
   
   func fetchListViewModel(at index: Int, handler: ((ListViewModelProtocol) -> Void))
 
-  func updateBoardDetailCollectionView()
+  func fetchBoardDetail()
   func updateBoardTitle(to title: String)
   func updatePosition(of sourceIndex: Int, to destinationIndex: Int)
   
@@ -98,7 +98,7 @@ final class BoardDetailViewModel: BoardDetailViewModelProtocol {
     return boardDetail?.lists[index]
   }
 
-  func updateBoardDetailCollectionView() {
+  func fetchBoardDetail() {
     boardService.fetchBoardDetail(with: boardId) { result in
       switch result {
       case .success(let boardDetail):
@@ -162,8 +162,9 @@ final class BoardDetailViewModel: BoardDetailViewModelProtocol {
   func createList(with title: String) {
     listService.createList(withBoardId: boardId, title: title) { result in
       switch result {
-      case .success(()):
-        self.updateBoardDetailCollectionView()
+      case .success(let list):
+        self.boardDetail?.lists.append(list)
+        self.updateBoardDetailCollectionViewHandler?()
         
       case .failure(let error):
         print(error)

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/ViewModel/BoardDetailViewModel.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/ViewModel/BoardDetailViewModel.swift
@@ -23,8 +23,8 @@ protocol BoardDetailViewModelProtocol {
 
   func fetchBoardDetail()
   func updateBoardTitle(to title: String)
-  func updatePosition(of sourceIndex: Int, to destinationIndex: Int)
-  
+  func updatePosition(of sourceIndex: Int, to destinationIndex: Int, handler: @escaping (Double) -> Void)
+
   func createList(with title: String)
   
   func makeUpdatedIndexPaths(by firstIndexPath: IndexPath, and secondIndexPath: IndexPath) -> [IndexPath]
@@ -129,7 +129,7 @@ final class BoardDetailViewModel: BoardDetailViewModelProtocol {
     }
   }
   
-  func updatePosition(of sourceIndex: Int, to destinationIndex: Int) {
+  func updatePosition(of sourceIndex: Int, to destinationIndex: Int, handler: @escaping (Double) -> Void) {
     guard let lists = boardDetail?.lists else { return }
     
     let listId = lists[sourceIndex].id
@@ -138,25 +138,24 @@ final class BoardDetailViewModel: BoardDetailViewModelProtocol {
     if destinationIndex == 0 {
       // 맨 앞에 넣는 경우
       position = lists[destinationIndex].position / 2
-      
     } else if destinationIndex == (lists.count-1) {
       // 맨 마지막에 넣는 경우
       position = lists[destinationIndex].position + 1
-      
+    } else if sourceIndex < destinationIndex {
+      position = (lists[destinationIndex].position + lists[destinationIndex+1].position) / 2
     } else {
       position = (lists[destinationIndex-1].position + lists[destinationIndex].position) / 2
     }
+    
+    listService.updateList(withListId: listId, position: position, title: nil) { result in
+      switch result {
+      case .success(_):
+        handler(position)
 
-    // TODO: API 에 버그가 있어서 수정되면 주석 해제
-//    listService.updateList(withListId: listId, position: position, title: nil) { result in
-//      switch result {
-//      case .success(()):
-//        break
-//
-//      case .failure(let error):
-//        print(error)
-//      }
-//    }
+      case .failure(let error):
+        print(error)
+      }
+    }
   }
   
   func createList(with title: String) {

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/ViewModel/ListViewModel.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/ViewModel/ListViewModel.swift
@@ -9,6 +9,7 @@ import Foundation
 
 protocol ListViewModelProtocol {
   
+  func bindingUpdateCollectionView(handler: @escaping () -> Void)
   func bindingUpdateListTitle(handler: @escaping (String) -> Void)
   
   func numberOfCards() -> Int
@@ -20,6 +21,7 @@ protocol ListViewModelProtocol {
   func removeCard(at index: Int)
   
   func updateListTitle(to title: String)
+  func updateCollectionView()
   
   func makeUpdatedIndexPaths(by firstIndexPath: IndexPath, and secondIndexPath: IndexPath) -> [IndexPath]
 }
@@ -32,8 +34,9 @@ final class ListViewModel: ListViewModelProtocol {
   private let cardService: CardServiceProtocol
   
   private var updateListTitleHandler: ((String) -> Void)?
+  private var updateCollectionViewHandler: (() -> Void)?
   
-  private let list: List
+  private let list: List 
   private var listTitle: String = ""
   
   // MARK: - Initializer
@@ -98,6 +101,10 @@ final class ListViewModel: ListViewModelProtocol {
       }
     }
   }
+  
+  func updateCollectionView() {
+    updateCollectionViewHandler?()
+  }
 }
 
 
@@ -130,6 +137,10 @@ extension ListViewModel {
 // MARK: - Extension bindUI
 
 extension ListViewModel {
+  
+  func bindingUpdateCollectionView(handler: @escaping () -> Void) {
+    updateCollectionViewHandler = handler
+  }
   
   func bindingUpdateListTitle(handler: @escaping (String) -> Void) {
     updateListTitleHandler = handler

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/ViewModel/ListViewModel.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/ViewModel/ListViewModel.swift
@@ -12,18 +12,21 @@ protocol ListViewModelProtocol {
   func bindingUpdateCollectionView(handler: @escaping () -> Void)
   func bindingUpdateListTitle(handler: @escaping (String) -> Void)
   
-  func numberOfCards() -> Int
   func fetchListId() -> Int
   func fetchListTitle() -> String
+  
+  func numberOfCards() -> Int
   func append(card: Card)
   func insert(card: Card, at index: Int)
   func fetchCard(at index: Int) -> Card
   func removeCard(at index: Int)
   
   func updateListTitle(to title: String)
+  func updateCardPosition(from sourceIndex: Int, to destinationIndex: Int, by card: Card, handler: @escaping () -> Void)
+  func updateCardPosition(from sourceIndex: Int, to destinationIndex: Int, by card: Card, in sourceViewModel: ListViewModelProtocol, handler: @escaping () -> Void)
+  func updateCardPosition(from sourceIndex: Int, by card: Card, in sourceViewModel: ListViewModelProtocol, handler: @escaping (Int) -> Void)
+
   func updateCollectionView()
-  
-  func makeUpdatedIndexPaths(by firstIndexPath: IndexPath, and secondIndexPath: IndexPath) -> [IndexPath]
 }
 
 final class ListViewModel: ListViewModelProtocol {
@@ -36,8 +39,12 @@ final class ListViewModel: ListViewModelProtocol {
   private var updateListTitleHandler: ((String) -> Void)?
   private var updateCollectionViewHandler: (() -> Void)?
   
-  private let list: List 
-  private var listTitle: String = ""
+  private let list: List
+  private var listTitle: String = "" {
+    didSet {
+      updateListTitleHandler?(listTitle)
+    }
+  }
   
   // MARK: - Initializer
   
@@ -92,11 +99,117 @@ final class ListViewModel: ListViewModelProtocol {
       title: title) { result in
       switch result {
       case .success(()):
-        self.updateListTitleHandler?(title)
         self.listTitle = title
         
       case .failure(let error):
-        self.updateListTitleHandler?(self.listTitle)
+        print(error)
+      }
+    }
+  }
+  
+  func updateCardPosition(
+    from sourceIndex: Int,
+    to destinationIndex: Int,
+    by card: Card,
+    handler: @escaping () -> Void
+  ) {
+    var position: Double
+    if destinationIndex == 0 {
+      // 맨 앞에 넣는 경우
+      position = list.cards[destinationIndex].position / 2
+    } else if destinationIndex == (list.cards.count-1) {
+      // 맨 마지막에 넣는 경우
+      position = list.cards[destinationIndex].position + 1
+    } else if sourceIndex < destinationIndex {
+      position = (list.cards[destinationIndex].position + list.cards[destinationIndex+1].position) / 2
+    } else {
+      position = (list.cards[destinationIndex-1].position + list.cards[destinationIndex].position) / 2
+    }
+    
+    cardService.updateCard(
+      id: card.id,
+      listId: fetchListId(),
+      position: position
+    ) { result in
+      switch result {
+      case .success(_):
+        self.removeCard(at: sourceIndex)
+        card.position = position
+        self.insert(card: card, at: destinationIndex)
+        
+        handler()
+
+      case .failure(let error):
+        print(error)
+      }
+    }
+  }
+  
+  func updateCardPosition(
+    from sourceIndex: Int,
+    to destinationIndex: Int,
+    by card: Card,
+    in sourceViewModel: ListViewModelProtocol,
+    handler: @escaping () -> Void
+  ) {
+    var position: Double
+    if destinationIndex == 0 {
+      // 맨 앞에 넣는 경우
+      position = list.cards[destinationIndex].position / 2
+    } else if destinationIndex == (list.cards.count) {
+      // 맨 마지막에 넣는 경우
+      position = list.cards[destinationIndex-1].position + 1
+    } else {
+      position = (list.cards[destinationIndex-1].position + list.cards[destinationIndex].position) / 2
+    }
+    
+    cardService.updateCard(
+      id: card.id,
+      listId: fetchListId(),
+      position: position
+      ) { result in
+      switch result {
+      case .success(_):
+        sourceViewModel.removeCard(at: sourceIndex)
+        card.position = position
+        self.insert(card: card, at: destinationIndex)
+
+        handler()
+        
+      case .failure(let error):
+        print(error)
+      }
+    }
+  }
+  
+  func updateCardPosition(
+    from sourceIndex: Int,
+    by card: Card,
+    in sourceViewModel: ListViewModelProtocol,
+    handler: @escaping (Int) -> Void
+  ) {
+    var position: Double
+    if list.cards.isEmpty {
+      position = 1
+    } else {
+      position = (list.cards.last?.position ?? 0) + 1
+    }
+    
+    cardService.updateCard(
+      id: card.id,
+      listId: fetchListId(),
+      position: position
+    ) { result in
+      switch result {
+      case .success(_):
+        sourceViewModel.removeCard(at: sourceIndex)
+        card.position = position
+        self.append(card: card)
+        
+        let lastIndex = self.numberOfCards() - 1
+        handler(lastIndex)
+
+      case .failure(let error):
         print(error)
       }
     }
@@ -104,32 +217,6 @@ final class ListViewModel: ListViewModelProtocol {
   
   func updateCollectionView() {
     updateCollectionViewHandler?()
-  }
-}
-
-
-// MARK: - Extension
-
-extension ListViewModel {
-  
-  func makeUpdatedIndexPaths(by firstIndexPath: IndexPath, and secondIndexPath: IndexPath) -> [IndexPath] {
-    var updatedIndexPaths: [IndexPath]
-    
-    if firstIndexPath.item < secondIndexPath.item {
-      updatedIndexPaths =
-        (firstIndexPath.item...secondIndexPath.item)
-        .map { IndexPath(row: $0, section: 0) }
-      
-    } else if firstIndexPath.item > secondIndexPath.item {
-      updatedIndexPaths =
-        (secondIndexPath.item...firstIndexPath.item)
-        .map { IndexPath(row: $0, section: 0) }
-      
-    } else {
-      updatedIndexPaths = []
-    }
-    
-    return updatedIndexPaths
   }
 }
 

--- a/iOS/AreUDone/AreUDone/CalendarScene/View/CardCollectionView/CardContentView.swift
+++ b/iOS/AreUDone/AreUDone/CalendarScene/View/CardCollectionView/CardContentView.swift
@@ -51,7 +51,7 @@ final class CardContentView: UIView {
   
   func updateContentView(with card: Card) {
     titleLabel.text = card.title
-    commentCountLabel.text = String(card.commentCount)
+    commentCountLabel.text = String(card.commentCount ?? 0)
   }
 }
 

--- a/iOS/AreUDone/AreUDone/CardAddScene/CardAddCoordinator.swift
+++ b/iOS/AreUDone/AreUDone/CardAddScene/CardAddCoordinator.swift
@@ -17,7 +17,7 @@ final class CardAddCoordinator: NavigationCoordinator {
   private var contentInputCoordinator: NavigationCoordinator!
 
   private let router: Routable
-  private let listId: Int
+  private let viewModel: ListViewModelProtocol
   
   private var storyboard: UIStoryboard {
     return UIStoryboard.load(storyboard: .cardAdd)
@@ -27,9 +27,9 @@ final class CardAddCoordinator: NavigationCoordinator {
   
   // MARK: - Initializer
   
-  init(router: Routable, listId: Int) {
+  init(router: Routable, viewModel: ListViewModelProtocol) {
     self.router = router
-    self.listId = listId
+    self.viewModel = viewModel
   }
   
   
@@ -42,7 +42,7 @@ final class CardAddCoordinator: NavigationCoordinator {
               guard let self = self else { return UIViewController() }
               
               let cardService = CardService(router: self.router)
-              let viewModel = CardAddViewModel(cardService: cardService, listId: self.listId)
+              let viewModel = CardAddViewModel(cardService: cardService, viewModel: self.viewModel)
               return CardAddViewController(coder: coder, viewModel: viewModel)
             }) as? CardAddViewController else { return UIViewController() }
     

--- a/iOS/AreUDone/AreUDone/CardAddScene/View/CardAddViewController.swift
+++ b/iOS/AreUDone/AreUDone/CardAddScene/View/CardAddViewController.swift
@@ -153,7 +153,9 @@ extension CardAddViewController {
     }
     
     viewModel.bindingPop() { [weak self] in
-      self?.coordinator?.dismiss()
+      DispatchQueue.main.async {
+        self?.coordinator?.dismiss()
+      }
     }
   }
 }

--- a/iOS/AreUDone/AreUDone/CardAddScene/ViewModel/CardAddViewModel.swift
+++ b/iOS/AreUDone/AreUDone/CardAddScene/ViewModel/CardAddViewModel.swift
@@ -34,7 +34,7 @@ final class CardAddViewModel: CardAddViewModelProtocol {
   // MARK: - Property
   
   private let cardService: CardServiceProtocol
-  private let listId: Int
+  private let viewModel: ListViewModelProtocol
   
   private var popHandler: (() -> Void)?
   private var isCreateEnableHandler: ((Bool) -> Void)?
@@ -53,9 +53,9 @@ final class CardAddViewModel: CardAddViewModelProtocol {
   
   // MARK: - Initializer
   
-  init(cardService: CardServiceProtocol, listId: Int) {
+  init(cardService: CardServiceProtocol, viewModel: ListViewModelProtocol) {
     self.cardService = cardService
-    self.listId = listId
+    self.viewModel = viewModel
   }
   
   
@@ -94,6 +94,7 @@ final class CardAddViewModel: CardAddViewModelProtocol {
   
   func createCard() {
     let dateString = selectedDate.toStringWithTime()
+    let listId = viewModel.fetchListId()
     cardService.createCard(
       listId: listId,
       title: listTitle,
@@ -101,7 +102,9 @@ final class CardAddViewModel: CardAddViewModelProtocol {
       content: content
     ) { result in
       switch result {
-      case .success(()):
+      case .success(let card):
+        self.viewModel.append(card: card)
+        self.viewModel.updateCollectionView()
         self.popHandler?()
         
       case .failure(let error):

--- a/iOS/AreUDone/AreUDone/Common/Model/Card.swift
+++ b/iOS/AreUDone/AreUDone/Common/Model/Card.swift
@@ -15,7 +15,7 @@ struct Cards: Codable {
 class Card: NSObject, Codable {
   let id: Int
   let title, dueDate: String
-  let position: Double
+  var position: Double
   let commentCount: Int
   
   init(

--- a/iOS/AreUDone/AreUDone/Common/Model/Card.swift
+++ b/iOS/AreUDone/AreUDone/Common/Model/Card.swift
@@ -15,14 +15,14 @@ struct Cards: Codable {
 class Card: NSObject, Codable {
   let id: Int
   let title, dueDate: String
-  let position: Int?
+  let position: Double
   let commentCount: Int
   
   init(
     id: Int,
     title: String,
     dueDate: String,
-    position: Int,
+    position: Double,
     commentCount: Int
   ) {
     self.id = id
@@ -30,6 +30,15 @@ class Card: NSObject, Codable {
     self.dueDate = dueDate
     self.position = position
     self.commentCount = commentCount
+  }
+  
+  required init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.id = try container.decode(Int.self, forKey: .id)
+    self.title = try container.decode(String.self, forKey: .title)
+    self.dueDate = try container.decode(String.self, forKey: .dueDate)
+    self.position = try container.decodeIfPresent(Double.self, forKey: .position) ?? 0
+    self.commentCount = try container.decodeIfPresent(Int.self, forKey: .commentCount) ?? 0
   }
 }
 

--- a/iOS/AreUDone/AreUDone/Common/Model/List.swift
+++ b/iOS/AreUDone/AreUDone/Common/Model/List.swift
@@ -8,11 +8,6 @@
 import Foundation
 import MobileCoreServices
 
-// TODO: API 연동 확인 후 삭제 예정
-//struct Lists: Codable {
-//  let lists: [List]
-//}
-
 class List: NSObject, Codable {
   let id: Int
   let title: String
@@ -24,6 +19,14 @@ class List: NSObject, Codable {
     self.title = title
     self.position = position
     self.cards = cards
+  }
+  
+  required init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.id = try container.decode(Int.self, forKey: .id)
+    self.title = try container.decode(String.self, forKey: .title)
+    self.position = try container.decodeIfPresent(Double.self, forKey: .position) ?? 0
+    self.cards = try container.decodeIfPresent([Card].self, forKey: .cards) ?? []
   }
 }
 

--- a/iOS/AreUDone/AreUDone/Common/Model/List.swift
+++ b/iOS/AreUDone/AreUDone/Common/Model/List.swift
@@ -11,7 +11,7 @@ import MobileCoreServices
 class List: NSObject, Codable {
   let id: Int
   let title: String
-  let position: Double
+  var position: Double
   var cards: [Card]
   
   init(id: Int, title: String, position: Double, cards: [Card]) {

--- a/iOS/AreUDone/AreUDone/Service/CardService/CardEndPoint.swift
+++ b/iOS/AreUDone/AreUDone/Service/CardService/CardEndPoint.swift
@@ -19,7 +19,7 @@ enum CardEndPoint {
         listId: Int?,
         title: String?,
         content: String?,
-        position: String?,
+        position: Double?,
         dueDate: String?
        )
   case updateCardMember(id: Int, userIds: [Int])
@@ -138,9 +138,9 @@ extension CardEndPoint: EndPointable {
       let position,
       let dueDate
     ):
-      var body = [String: String]()
+      var body = [String: Any]()
       if let listId = listId {
-        body["listId"] = "\(listId)"
+        body["listId"] = listId
       }
       
       if let title = title {

--- a/iOS/AreUDone/AreUDone/Service/CardService/CardService.swift
+++ b/iOS/AreUDone/AreUDone/Service/CardService/CardService.swift
@@ -18,7 +18,7 @@ protocol CardServiceProtocol {
     listId: Int?,
     title: String?,
     content: String?,
-    position: String?,
+    position: Double?,
     dueDate: String?,
     completionHandler: @escaping ((Result<Void, APIError>) -> Void)
   )
@@ -37,7 +37,7 @@ extension CardServiceProtocol {
     listId: Int? = nil,
     title: String? = nil,
     content: String? = nil,
-    position: String? = nil,
+    position: Double? = nil,
     dueDate: String? = nil,
     completionHandler: @escaping ((Result<Void, APIError>) -> Void)
   ) {
@@ -92,7 +92,7 @@ class CardService: CardServiceProtocol {
     listId: Int? = nil,
     title: String? = nil,
     content: String? = nil,
-    position: String? = nil,
+    position: Double? = nil,
     dueDate: String? = nil,
     completionHandler: @escaping ((Result<Void, APIError>) -> Void)
   ) {

--- a/iOS/AreUDone/AreUDone/Service/CardService/CardService.swift
+++ b/iOS/AreUDone/AreUDone/Service/CardService/CardService.swift
@@ -11,7 +11,7 @@ import NetworkFramework
 protocol CardServiceProtocol {
   
   func fetchDailyCards(dateString: String, option: FetchDailyCardsOption, completionHandler: @escaping (Result<Cards, APIError>) -> Void)
-  func createCard(listId: Int, title: String, dueDate: String, content: String, completionHandler: @escaping (Result<Void, APIError>) -> Void)
+  func createCard(listId: Int, title: String, dueDate: String, content: String, completionHandler: @escaping (Result<Card, APIError>) -> Void)
   func fetchDetailCard(id: Int, completionHandler: @escaping ((Result<CardDetail, APIError>) -> Void))
   func updateCard(
     id: Int,
@@ -75,7 +75,7 @@ class CardService: CardServiceProtocol {
     }
   }
   
-  func createCard(listId: Int, title: String, dueDate: String, content: String, completionHandler: @escaping (Result<Void, APIError>) -> Void) {
+  func createCard(listId: Int, title: String, dueDate: String, content: String, completionHandler: @escaping (Result<Card, APIError>) -> Void) {
     router.request(route: CardEndPoint.createCard(listId: listId, title: title, dueDate: dueDate, content: content)) { result in
       completionHandler(result)
     }

--- a/iOS/AreUDone/AreUDone/Service/ListService/ListService.swift
+++ b/iOS/AreUDone/AreUDone/Service/ListService/ListService.swift
@@ -9,7 +9,7 @@ import Foundation
 import NetworkFramework
 
 protocol ListServiceProtocol {
-  func createList(withBoardId boardId: Int, title: String, completionHandler: @escaping (Result<Void, APIError>) -> Void)
+  func createList(withBoardId boardId: Int, title: String, completionHandler: @escaping (Result<List, APIError>) -> Void)
   func deleteList(withListId listId: Int, completionHandler: @escaping (Result<Void, APIError>) -> Void)
   func updateList(withListId listId: Int, position: Double?, title: String?, completionHandler: @escaping (Result<Void, APIError>) -> Void)
 }
@@ -37,7 +37,7 @@ class ListService: ListServiceProtocol {
   
   // MARK: - Method
   
-  func createList(withBoardId boardId: Int, title: String, completionHandler: @escaping (Result<Void, APIError>) -> Void) {
+  func createList(withBoardId boardId: Int, title: String, completionHandler: @escaping (Result<List, APIError>) -> Void) {
     router.request(route: ListEndPoint.createList(boardId: boardId, title: title)) { result in
       completionHandler(result)
     }


### PR DESCRIPTION
# 리스트/카드 포지션 변경 로직 적용

## 📎 해당 이슈

#265

## 🛠 구현 내용 

- 리스트 포지션 변경 로직 구현 
- 카드 포지션 변경 로직 구현
- UI 변경 로직 / 포지션 계산 로직 ViewController / ViewModel 로 분리
- cell 이 insert 되거나 delete 된 컬렉션뷰를 갱신할 때 reloadSection or data 로 모든 veiw 를 갱신하는 것이 아니라,
  insert, deleteItems(at) 을 이용하여 변경이 일어난 일부 cell 에 대해서만 갱신을 하도록 했습니다

## 🙋‍ 리뷰어 참고 사항 

