### PR TITLE
카드 멤버 모달창 카드 API 데이터와 연동

### DIFF
--- a/client/src/components/boardPage/List.js
+++ b/client/src/components/boardPage/List.js
@@ -236,7 +236,7 @@ export default function List({ title, id, index, moveList, position }) {
                     <AiOutlineMenu onClick={menuClickHandler} style={{ cursor: 'pointer' }} />
                 </ListContentWrapper>
                 <CardsWrapper>
-                    {boardDetail.lists[index].cards.map((v, cardInd) => (
+                    {boardDetail.lists[index].cards?.map((v, cardInd) => (
                         <Card
                             width="230px"
                             height="60px"

--- a/client/src/components/cardModal/CardMemberContainer.js
+++ b/client/src/components/cardModal/CardMemberContainer.js
@@ -24,7 +24,8 @@ const CardMemberContainer = ({ members }) => {
         <Wrapper>
             <CardMemberHeader>멤버</CardMemberHeader>
             <CardMemberWrapper>
-                {members !== [] && members.map((member) => <Member member={member} />)}
+                {members !== [] &&
+                    members.map((member) => <Member key={member.id} member={member} />)}
             </CardMemberWrapper>
         </Wrapper>
     );

--- a/client/src/components/cardModal/CardMemberContainer.js
+++ b/client/src/components/cardModal/CardMemberContainer.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import styled from 'styled-components';
+import Member from './Member';
+
+const Wrapper = styled.div`
+    width: 100%;
+    height: 5rem;
+    margin: 0 3rem;
+`;
+
+const CardMemberHeader = styled.div`
+    color: #192b4d;
+    font-weight: bold;
+`;
+
+const CardMemberWrapper = styled.div`
+    display: flex;
+    margin: 5px 0;
+    font-size: 0.9rem;
+`;
+
+const CardMemberContainer = ({ members }) => {
+    return (
+        <Wrapper>
+            <CardMemberHeader>멤버</CardMemberHeader>
+            <CardMemberWrapper>
+                {members !== [] && members.map((member) => <Member member={member} />)}
+            </CardMemberWrapper>
+        </Wrapper>
+    );
+};
+
+export default CardMemberContainer;

--- a/client/src/components/cardModal/CardModal.js
+++ b/client/src/components/cardModal/CardModal.js
@@ -5,6 +5,7 @@ import CardDueDateContainer from './CardDueDateContainer';
 import CardModalButton from './CardModalButton';
 import CardTitleContainer from './CardTitleContainer';
 import CommentContainer from './CommentContainer';
+import CardMemberContainer from './CardMemberContainer';
 import { getCard } from '../../utils/cardRequest';
 
 const DimmedModal = styled.div`
@@ -42,7 +43,6 @@ const ModalInner = styled.div`
     transform: translate(-50%, -50%);
     padding: 1rem;
     border-radius: 0.2rem;
-    overflow-y: scroll;
 `;
 
 const CardModalLeftSideBar = styled.div`
@@ -131,6 +131,7 @@ const CardModal = ({ visible, closeModal, cardId }) => {
                             cardTitle={card.title}
                             cardListTitle={card.list.title}
                         />
+                        <CardMemberContainer members={card.members} />
                         <CardDueDateContainer dueDate={card.dueDate} />
                         <CardDescriptionContainer cardContent={card.content} />
                         <CommentContainer comments={card.comments} />

--- a/client/src/components/cardModal/CardModal.js
+++ b/client/src/components/cardModal/CardModal.js
@@ -6,7 +6,9 @@ import CardModalButton from './CardModalButton';
 import CardTitleContainer from './CardTitleContainer';
 import CommentContainer from './CommentContainer';
 import CardMemberContainer from './CardMemberContainer';
+import MemberButton from '../common/MemberButton';
 import { getCard } from '../../utils/cardRequest';
+import CardContext from '../../context/CardContext';
 
 const DimmedModal = styled.div`
     display: ${(props) => (props.visible ? 'block' : 'none')};
@@ -82,6 +84,11 @@ const cardReducer = (state, action) => {
                 data: action.data,
                 error: null,
             };
+        case 'CHANGE_MEMBER':
+            return {
+                ...state,
+                data: action.data,
+            };
         case 'ERROR':
             return {
                 loading: false,
@@ -123,34 +130,34 @@ const CardModal = ({ visible, closeModal, cardId }) => {
     };
     return (
         <>
-            <DimmedModal visible={visible} />
-            <ModalWrapper onClick={onDimmedClick} visible={visible}>
-                <ModalInner>
-                    <CardModalLeftSideBar>
-                        <CardTitleContainer
-                            cardTitle={card.title}
-                            cardListTitle={card.list.title}
-                        />
-                        <CardMemberContainer members={card.members} />
-                        <CardDueDateContainer dueDate={card.dueDate} />
-                        <CardDescriptionContainer cardContent={card.content} />
-                        <CommentContainer comments={card.comments} />
-                    </CardModalLeftSideBar>
-                    <CardModalRightSideBar>
-                        <ButtonList>
-                            <CardModalButton width="10rem" height="2rem">
-                                멤버 추가
-                            </CardModalButton>
-                            <CardModalButton width="10rem" height="2rem">
-                                마감 기한
-                            </CardModalButton>
-                            <CardModalButton width="10rem" height="2rem">
-                                카드 이동
-                            </CardModalButton>
-                        </ButtonList>
-                    </CardModalRightSideBar>
-                </ModalInner>
-            </ModalWrapper>
+            <CardContext.Provider value={{ cardState, cardDispatch }}>
+                <DimmedModal visible={visible} />
+                <ModalWrapper onClick={onDimmedClick} visible={visible}>
+                    <ModalInner>
+                        <CardModalLeftSideBar>
+                            <CardTitleContainer
+                                cardTitle={card.title}
+                                cardListTitle={card.list.title}
+                            />
+                            <CardMemberContainer members={card.members} />
+                            <CardDueDateContainer dueDate={card.dueDate} />
+                            <CardDescriptionContainer cardContent={card.content} />
+                            <CommentContainer comments={card.comments} />
+                        </CardModalLeftSideBar>
+                        <CardModalRightSideBar>
+                            <ButtonList>
+                                <MemberButton />
+                                <CardModalButton width="10rem" height="2rem">
+                                    마감 기한
+                                </CardModalButton>
+                                <CardModalButton width="10rem" height="2rem">
+                                    카드 이동
+                                </CardModalButton>
+                            </ButtonList>
+                        </CardModalRightSideBar>
+                    </ModalInner>
+                </ModalWrapper>
+            </CardContext.Provider>
         </>
     );
 };

--- a/client/src/components/cardModal/Member.js
+++ b/client/src/components/cardModal/Member.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const UserDiv = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+    padding: 5px;
+    max-width: 60px;
+`;
+
+const ProfileImageDiv = styled.div`
+    width: 30px;
+    height: 30px;
+    border-radius: 70%;
+    overflow: hidden;
+`;
+
+const ProfileImage = styled.img`
+    width: 100%;
+    height: 100%;
+`;
+
+const NameDiv = styled.div``;
+
+const Member = ({ member }) => {
+    return (
+        <UserDiv>
+            <ProfileImageDiv>
+                <ProfileImage
+                    src={member.profileImageUrl}
+                    alt={`${member.name} image`}
+                    align="center"
+                />
+            </ProfileImageDiv>
+            <NameDiv>{member.name}</NameDiv>
+        </UserDiv>
+    );
+};
+
+export default Member;

--- a/client/src/components/common/Member.js
+++ b/client/src/components/common/Member.js
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import styled from 'styled-components';
 import { FcCheckmark } from 'react-icons/fc';
+import CardContext from '../../context/CardContext';
 
 const UserDiv = styled.div`
     display: flex;
@@ -36,16 +37,22 @@ const NameDiv = styled.div`
     margin: auto 10px;
 `;
 
-const Member = ({ memberId, profileImageUrl, name, checked, selectedMember, changeMember }) => {
-    const onClickMember = (id) => {
-        if (checked) {
-            const index = selectedMember.findIndex((member) => member.id === id);
-            selectedMember.splice(index, 1);
-            return changeMember([...selectedMember]);
-        }
-        const newMember = { id, profileImageUrl, name };
+const Member = ({ memberId, profileImageUrl, name }) => {
+    const { cardState, cardDispatch } = useContext(CardContext);
+    const card = cardState.data;
+    const { members } = card;
+    const checked = members.some((member) => member.id === memberId);
 
-        return changeMember([...selectedMember, newMember]);
+    const onClickMember = async (id) => {
+        let newMembers = members;
+        if (checked) {
+            // const index = members.findIndex((member) => member.id === id);
+            newMembers = members.filter((member) => member.id !== id);
+        } else {
+            const newMember = { id, profileImageUrl, name };
+            newMembers = [...members, newMember];
+        }
+        cardDispatch({ type: 'CHANGE_MEMBER', data: { ...card, members: newMembers } });
     };
 
     return (

--- a/client/src/components/common/Member.js
+++ b/client/src/components/common/Member.js
@@ -39,11 +39,13 @@ const NameDiv = styled.div`
 const Member = ({ memberId, profileImageUrl, name, checked, selectedMember, changeMember }) => {
     const onClickMember = (id) => {
         if (checked) {
-            const index = selectedMember.findIndex((member) => member === id);
+            const index = selectedMember.findIndex((member) => member.id === id);
             selectedMember.splice(index, 1);
             return changeMember([...selectedMember]);
         }
-        return changeMember([...selectedMember, id]);
+        const newMember = { id, profileImageUrl, name };
+
+        return changeMember([...selectedMember, newMember]);
     };
 
     return (

--- a/client/src/components/common/Member.js
+++ b/client/src/components/common/Member.js
@@ -46,7 +46,6 @@ const Member = ({ memberId, profileImageUrl, name }) => {
     const onClickMember = async (id) => {
         let newMembers = members;
         if (checked) {
-            // const index = members.findIndex((member) => member.id === id);
             newMembers = members.filter((member) => member.id !== id);
         } else {
             const newMember = { id, profileImageUrl, name };

--- a/client/src/components/common/MemberModal.js
+++ b/client/src/components/common/MemberModal.js
@@ -2,9 +2,9 @@ import React, { useContext, useState } from 'react';
 import styled from 'styled-components';
 import { IoIosClose } from 'react-icons/io';
 import BoardDetailContext from '../../context/BoardDetailContext';
+import Member from './Member';
 import CardContext from '../../context/CardContext';
 import { addMemberToCard } from '../../utils/cardRequest';
-import Member from './Member';
 
 const Wrapper = styled.div`
     position: fixed;
@@ -56,18 +56,16 @@ const SearchInput = styled.input.attrs({
 const MemberModal = ({ onClose }) => {
     const { boardDetail } = useContext(BoardDetailContext);
     const { creator, invitedUsers } = boardDetail;
-    const { cardState, cardDispatch } = useContext(CardContext);
+    const { cardState } = useContext(CardContext);
     const card = cardState.data;
-    const [members, setMembers] = useState(card.members);
     const allInvitedUsers = [creator, ...invitedUsers];
     const [searchedUsers, setSearchedUsers] = useState(allInvitedUsers);
 
     const onClickClose = async (e) => {
         if (e.target === e.currentTarget) {
             const cardId = card.id;
-            const userIds = members.map((member) => member.id);
+            const userIds = card.members.map((member) => member.id);
             await addMemberToCard({ cardId, userIds });
-            cardDispatch({ type: 'CHANGE_MEMBER', data: { ...card, members } });
             onClose();
         }
     };
@@ -96,15 +94,7 @@ const MemberModal = ({ onClose }) => {
                 </ModalHeader>
                 <SearchInput onChange={onChangeUserSearch} />
                 {searchedUsers.map(({ id, profileImageUrl, name }) => (
-                    <Member
-                        key={id}
-                        memberId={id}
-                        profileImageUrl={profileImageUrl}
-                        name={name}
-                        checked={members.some((member) => member.id === id)}
-                        selectedMember={members}
-                        changeMember={setMembers}
-                    />
+                    <Member key={id} memberId={id} profileImageUrl={profileImageUrl} name={name} />
                 ))}
             </ModalWrapper>
         </>

--- a/client/src/components/common/MemberModal.js
+++ b/client/src/components/common/MemberModal.js
@@ -2,6 +2,7 @@ import React, { useContext, useState } from 'react';
 import styled from 'styled-components';
 import { IoIosClose } from 'react-icons/io';
 import BoardDetailContext from '../../context/BoardDetailContext';
+import CardContext from '../../context/CardContext';
 import { addMemberToCard } from '../../utils/cardRequest';
 import Member from './Member';
 
@@ -55,17 +56,18 @@ const SearchInput = styled.input.attrs({
 const MemberModal = ({ onClose }) => {
     const { boardDetail } = useContext(BoardDetailContext);
     const { creator, invitedUsers } = boardDetail;
-    // TODO: 카드에 members 정보를 default 값으로 변경
-    const [userIds, setUserIds] = useState([1, 2]);
+    const { cardState, cardDispatch } = useContext(CardContext);
+    const card = cardState.data;
+    const [members, setMembers] = useState(card.members);
     const allInvitedUsers = [creator, ...invitedUsers];
     const [searchedUsers, setSearchedUsers] = useState(allInvitedUsers);
-    allInvitedUsers.sort((a) => (userIds.includes(a.id) ? -1 : 1));
 
     const onClickClose = async (e) => {
         if (e.target === e.currentTarget) {
-            // TODO: context에 저장된 카드 id 가져오도록 변경할 것
-            const cardId = 1;
+            const cardId = card.id;
+            const userIds = members.map((member) => member.id);
             await addMemberToCard({ cardId, userIds });
+            cardDispatch({ type: 'CHANGE_MEMBER', data: { ...card, members } });
             onClose();
         }
     };
@@ -80,7 +82,6 @@ const MemberModal = ({ onClose }) => {
 
         const regex = new RegExp(`^${text}`);
         const newSearchUsers = allInvitedUsers.filter((user) => user.name.search(regex) !== -1);
-        newSearchUsers.sort((a) => (userIds.includes(a.id) ? -1 : 1));
         setSearchedUsers(newSearchUsers);
     };
 
@@ -91,7 +92,7 @@ const MemberModal = ({ onClose }) => {
                 <ModalHeader>
                     <div />
                     <ModalTitle>멤버</ModalTitle>
-                    <IoIosClose size={24} cursor="pointer" onClick={onClose} />
+                    <IoIosClose size={24} cursor="pointer" onClick={onClickClose} />
                 </ModalHeader>
                 <SearchInput onChange={onChangeUserSearch} />
                 {searchedUsers.map(({ id, profileImageUrl, name }) => (
@@ -100,9 +101,9 @@ const MemberModal = ({ onClose }) => {
                         memberId={id}
                         profileImageUrl={profileImageUrl}
                         name={name}
-                        checked={userIds.includes(id)}
-                        selectedMember={userIds}
-                        changeMember={setUserIds}
+                        checked={members.some((member) => member.id === id)}
+                        selectedMember={members}
+                        changeMember={setMembers}
                     />
                 ))}
             </ModalWrapper>

--- a/client/src/context/CardContext.js
+++ b/client/src/context/CardContext.js
@@ -1,0 +1,5 @@
+import { createContext } from 'react';
+
+const CardContext = createContext({});
+
+export default CardContext;


### PR DESCRIPTION
# 카드 멤버 모달창 카드 데이터와 연동

## 📎 해당 이슈

이슈 링크 (#186 )

## 🛠 구현 내용 

- 카드 상세 모달에 멤버 컴포넌트 추가
- 멤버 모달에서 추가, 삭제 시, 상세 모달의 멤버 컴포넌트가 변경되도록 구현
- 멤버 모달이 닫힐 때, 카드 멤버 추가/삭제 API 요청하도록 구현

## 🙋‍ 리뷰어 참고 사항 
![image](https://user-images.githubusercontent.com/49746644/102083029-445d3200-3e56-11eb-820c-619a1e0e64fd.png)

