### PR TITLE
카드 상세 모달의 마감기한 변경 컴포넌트 추가

### DIFF
--- a/client/src/components/cardModal/CardDueDateContainer.js
+++ b/client/src/components/cardModal/CardDueDateContainer.js
@@ -5,6 +5,7 @@ import moment from 'moment';
 import CardModalButton from './CardModalButton';
 import CloseButton from './CloseButton';
 import CardContext from '../../context/CardContext';
+import { modifyCardDueDate } from '../../utils/cardRequest';
 
 const Wrapper = styled.div`
     display: grid;
@@ -57,8 +58,11 @@ const CardDueDateContainer = ({ dueDate }) => {
     const card = cardState.data;
     const dateFormat = 'YYYY-MM-DD HH:mm:ss';
 
-    const onClickChangeDueDate = (value) => {
+    const onClickChangeDueDate = async (value) => {
+        const cardId = card.id;
         const newDueDate = moment(new Date(value)).format('YYYY-MM-DD HH:mm:ss');
+        await modifyCardDueDate({ cardId, dueDate: newDueDate });
+
         const data = { ...card, dueDate: newDueDate };
         cardDispatch({ type: 'CHANGE_DUEDATE', data });
         setIsDisplay(false);

--- a/client/src/components/cardModal/CardDueDateContainer.js
+++ b/client/src/components/cardModal/CardDueDateContainer.js
@@ -1,6 +1,10 @@
-import React from 'react';
+import React, { useContext, useState } from 'react';
 import styled from 'styled-components';
+import { DatePicker } from 'antd';
+import moment from 'moment';
 import CardModalButton from './CardModalButton';
+import CloseButton from './CloseButton';
+import CardContext from '../../context/CardContext';
 
 const Wrapper = styled.div`
     display: grid;
@@ -31,11 +35,56 @@ const CardDueDate = styled(CardModalButton)`
     grid-row-end: 3;
 `;
 
+const DatePickerWrapper = styled.div`
+    height: 2rem;
+    font-size: 0.9rem;
+    grid-column-start: 2;
+    grid-column-end: 3;
+    grid-row-start: 2;
+    grid-row-end: 3;
+`;
+
+const CardCloseButton = styled(CloseButton)`
+    grid-column-start: 2;
+    grid-column-end: 3;
+    grid-row-start: 3;
+    grid-row-end: 4;
+`;
+
 const CardDueDateContainer = ({ dueDate }) => {
+    const [isDisplay, setIsDisplay] = useState(false);
+    const { cardState, cardDispatch } = useContext(CardContext);
+    const card = cardState.data;
+    const dateFormat = 'YYYY-MM-DD HH:mm:ss';
+
+    const onClickChangeDueDate = (value) => {
+        const newDueDate = moment(new Date(value)).format('YYYY-MM-DD HH:mm:ss');
+        const data = { ...card, dueDate: newDueDate };
+        cardDispatch({ type: 'CHANGE_DUEDATE', data });
+        setIsDisplay(false);
+    };
+
     return (
         <Wrapper>
             <CardDueDateHeader>마감 기한</CardDueDateHeader>
-            <CardDueDate>{dueDate}</CardDueDate>
+            <CardDueDate onClick={() => setIsDisplay(true)}>{dueDate}</CardDueDate>
+            {isDisplay && (
+                <DatePickerWrapper>
+                    <DatePicker
+                        showTime
+                        defaultValue={moment(
+                            `${new Date(dueDate).toISOString().slice(0, -1)}`,
+                            dateFormat,
+                        )}
+                        format={dateFormat}
+                        onOk={onClickChangeDueDate}
+                        clearIcon={false}
+                    />
+                    <CardCloseButton width="2rem" onClick={() => setIsDisplay(false)}>
+                        X
+                    </CardCloseButton>
+                </DatePickerWrapper>
+            )}
         </Wrapper>
     );
 };

--- a/client/src/components/cardModal/CardModal.js
+++ b/client/src/components/cardModal/CardModal.js
@@ -7,6 +7,7 @@ import CardTitleContainer from './CardTitleContainer';
 import CommentContainer from './CommentContainer';
 import CardMemberContainer from './CardMemberContainer';
 import MemberButton from '../common/MemberButton';
+import MoveButton from '../common/MoveButton';
 import { getCard } from '../../utils/cardRequest';
 import CardContext from '../../context/CardContext';
 
@@ -89,6 +90,11 @@ const cardReducer = (state, action) => {
                 ...state,
                 data: action.data,
             };
+        case 'CHANGE_DUEDATE':
+            return {
+                ...state,
+                data: action.data,
+            };
         case 'ERROR':
             return {
                 loading: false,
@@ -153,6 +159,7 @@ const CardModal = ({ visible, closeModal, cardId }) => {
                                 <CardModalButton width="10rem" height="2rem">
                                     카드 이동
                                 </CardModalButton>
+                                <MoveButton />
                             </ButtonList>
                         </CardModalRightSideBar>
                     </ModalInner>

--- a/client/src/components/cardModal/CardModal.js
+++ b/client/src/components/cardModal/CardModal.js
@@ -2,7 +2,6 @@ import React, { useEffect, useReducer } from 'react';
 import styled from 'styled-components';
 import CardDescriptionContainer from './CardDescriptionContainer';
 import CardDueDateContainer from './CardDueDateContainer';
-import CardModalButton from './CardModalButton';
 import CardTitleContainer from './CardTitleContainer';
 import CommentContainer from './CommentContainer';
 import CardMemberContainer from './CardMemberContainer';
@@ -153,12 +152,6 @@ const CardModal = ({ visible, closeModal, cardId }) => {
                         <CardModalRightSideBar>
                             <ButtonList>
                                 <MemberButton />
-                                <CardModalButton width="10rem" height="2rem">
-                                    마감 기한
-                                </CardModalButton>
-                                <CardModalButton width="10rem" height="2rem">
-                                    카드 이동
-                                </CardModalButton>
                                 <MoveButton />
                             </ButtonList>
                         </CardModalRightSideBar>


### PR DESCRIPTION
# 카드 상세 모달의 마감기한 변경 컴포넌트 추가

## 📎 해당 이슈

이슈 링크 (#244 )

## 🛠 구현 내용 

- 마감 기한 클릭시, 변경 가능한 datepicker가 보이도록 구현
- OK 버튼 클릭시, 마감기한 수정 API 요청

## 🙋‍ 리뷰어 참고 사항 
![image](https://user-images.githubusercontent.com/49746644/102089368-732bd600-3e5f-11eb-8722-1b8c88eea07a.png)

