### PR TITLE
카드 상세 조회 API 응답 값에 position 값 추가

### DIFF
--- a/server/src/service/CardService.js
+++ b/server/src/service/CardService.js
@@ -161,6 +161,7 @@ export class CardService extends BaseService {
             title: card.title,
             content: card.content,
             dueDate: moment(card.dueDate).tz('Asia/Seoul').format(),
+            position: card.position,
             list: {
                 id: list.id,
                 title: list.title,

--- a/server/test/router/card/CardRouter.getCardByCardId.test.js
+++ b/server/test/router/card/CardRouter.getCardByCardId.test.js
@@ -190,6 +190,7 @@ describe('GET /api/card/:cardId', () => {
                 title: card0.title,
                 content: card0.content,
                 dueDate: card0.dueDate,
+                position: card0.position,
                 list: {
                     id: list0.id,
                     title: list0.title,

--- a/server/test/service/card/CardService.getCard.test.js
+++ b/server/test/service/card/CardService.getCard.test.js
@@ -171,6 +171,7 @@ describe('CardService.getCard() Test', () => {
                 title: card0.title,
                 content: card0.content,
                 dueDate: card0.dueDate,
+                position: card0.position,
                 list: {
                     id: list0.id,
                     title: list0.title,


### PR DESCRIPTION
# 카드 상세 조회 API 응답 값에 position 값 추가

## 📎 해당 이슈

이슈 링크 (#309 )

## 🛠 구현 내용 

- 카드 상세 조회 API 응답 값에 position 값 추가
- 응답 값 변경에 따른 테스트 코드 수정

## 🙋‍ 리뷰어 참고 사항 

카드 이동 모달창에 position 값이 필요하여 추가하였습니다!