### PR TITLE
카드 이동 모달 이동 이벤트 추가

### DIFF
--- a/client/src/components/cardModal/CardModal.js
+++ b/client/src/components/cardModal/CardModal.js
@@ -2,11 +2,11 @@ import React, { useEffect, useReducer } from 'react';
 import styled from 'styled-components';
 import CardDescriptionContainer from './CardDescriptionContainer';
 import CardDueDateContainer from './CardDueDateContainer';
-import CardModalButton from './CardModalButton';
 import CardTitleContainer from './CardTitleContainer';
 import CommentContainer from './CommentContainer';
 import CardMemberContainer from './CardMemberContainer';
 import MemberButton from '../common/MemberButton';
+import MoveButton from '../common/MoveButton';
 import { getCard } from '../../utils/cardRequest';
 import CardContext from '../../context/CardContext';
 
@@ -89,6 +89,11 @@ const cardReducer = (state, action) => {
                 ...state,
                 data: action.data,
             };
+        case 'CHANGE_POSITION':
+            return {
+                ...state,
+                data: action.data,
+            };
         case 'ERROR':
             return {
                 loading: false,
@@ -147,12 +152,7 @@ const CardModal = ({ visible, closeModal, cardId }) => {
                         <CardModalRightSideBar>
                             <ButtonList>
                                 <MemberButton />
-                                <CardModalButton width="10rem" height="2rem">
-                                    마감 기한
-                                </CardModalButton>
-                                <CardModalButton width="10rem" height="2rem">
-                                    카드 이동
-                                </CardModalButton>
+                                <MoveButton />
                             </ButtonList>
                         </CardModalRightSideBar>
                     </ModalInner>

--- a/client/src/components/common/MemberButton.js
+++ b/client/src/components/common/MemberButton.js
@@ -7,8 +7,9 @@ const Wrapper = styled.div`
 `;
 
 const Button = styled.button`
-    margin: 5px 10px;
     padding: 5px 10px;
+    width: 10em;
+    border: ${(props) => props.theme.border};
 `;
 
 const MemberButton = () => {

--- a/client/src/components/common/MemberModal.js
+++ b/client/src/components/common/MemberModal.js
@@ -8,10 +8,10 @@ import { addMemberToCard } from '../../utils/cardRequest';
 
 const Wrapper = styled.div`
     position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
+    top: -30%;
+    left: -30%;
+    width: 200%;
+    height: 200%;
 `;
 
 const ModalWrapper = styled.div`

--- a/client/src/components/common/MoveButton.js
+++ b/client/src/components/common/MoveButton.js
@@ -7,8 +7,9 @@ const Wrapper = styled.div`
 `;
 
 const Button = styled.button`
-    margin: 5px 10px;
     padding: 5px 10px;
+    width: 10em;
+    border: ${(props) => props.theme.border};
 `;
 
 const MoveButton = () => {

--- a/client/src/components/common/MoveModal.js
+++ b/client/src/components/common/MoveModal.js
@@ -84,6 +84,7 @@ const MoveModal = ({ onClose }) => {
     const currentCard = lists[currentListIndex].cards[currentCardIndex];
     const currentCardPosition = cardInfo.position;
     const [selectedList, setSelectedList] = useState(lists[currentListIndex]);
+    const isEmptyList = selectedList.cards[0].id === 0;
     const listElement = useRef();
     const positionElement = useRef();
 
@@ -171,14 +172,23 @@ const MoveModal = ({ onClose }) => {
                             id="position-select"
                             defaultValue={currentCardPosition}
                         >
-                            {selectedList.cards.map((card, index) => (
-                                <option key={card.id} value={card.position}>
-                                    {card.id === cardId ? `${index + 1} (current)` : index + 1}
-                                </option>
-                            ))}
+                            {!isEmptyList &&
+                                selectedList.cards.map((card, index) => (
+                                    <option key={card.id} value={card.position}>
+                                        {card.id === cardId ? `${index + 1} (current)` : index + 1}
+                                    </option>
+                                ))}
                             {currentListId !== selectedList.id && (
-                                <option value={selectedList.cards.length + 1}>
-                                    {selectedList.cards.length + 1}
+                                <option
+                                    value={
+                                        isEmptyList
+                                            ? selectedList.cards.length
+                                            : selectedList.cards.length + 1
+                                    }
+                                >
+                                    {isEmptyList
+                                        ? selectedList.cards.length
+                                        : selectedList.cards.length + 1}
                                 </option>
                             )}
                         </Select>

--- a/client/src/components/common/MoveModal.js
+++ b/client/src/components/common/MoveModal.js
@@ -7,10 +7,10 @@ import { modifyCardPosition } from '../../utils/cardRequest';
 
 const Wrapper = styled.div`
     position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
+    top: -30%;
+    left: -30%;
+    width: 200%;
+    height: 200%;
 `;
 
 const ModalWrapper = styled.div`


### PR DESCRIPTION
# 카드 이동 모달 이동 이벤트 추가

## 📎 해당 이슈

이슈 링크 (#185 )

## 🛠 구현 내용 

- 카드 이동 모달을 통해 카드 위치를 옮기게 되면 컴포넌트의 위치도 함꼐 이동되도록 이벤트 추가
- 비어있는 리스트의 경우, 위치 select의 option이 2개가 생기는 오류 수정
- css 수정

## 🙋‍ 리뷰어 참고 사항 
![image](https://user-images.githubusercontent.com/49746644/102105551-e5f27c80-3e72-11eb-99ee-34d89846df8d.png)

TODO로 남겨놓은 것 모두 해결했습니다:D