### PR TITLE
타임존 및 날짜 반환 형식 변경 완료

### DIFF
--- a/server/src/common/config/database/ConnectionOptionGenerator.js
+++ b/server/src/common/config/database/ConnectionOptionGenerator.js
@@ -13,6 +13,7 @@ class ConnectionOptionGenerator {
             logging: this.databaseEnv.getDatabaseLogging(),
             dropSchema: this.databaseEnv.getDatabaseDropSchema(),
             synchronize: this.databaseEnv.getDatabaseSynchronize(),
+            timezone: '+09:00',
             extra: {},
         };
 

--- a/server/src/dto/CardDto.js
+++ b/server/src/dto/CardDto.js
@@ -3,16 +3,6 @@ import { IsISO8601, IsNotEmpty, IsNumber, IsString, ValidateIf } from 'class-val
 export class CardDto {
     id;
 
-    title;
-
-    content;
-
-    position;
-
-    dueDate;
-
-    listId;
-
     @ValidateIf((o) => o.title !== undefined)
     @IsString()
     @IsNotEmpty()

--- a/server/src/router/CardRouter.js
+++ b/server/src/router/CardRouter.js
@@ -1,3 +1,4 @@
+import moment from 'moment-timezone';
 import { Router } from 'express';
 import { isNumberString } from 'class-validator';
 import { CardService } from '../service/CardService';
@@ -66,7 +67,7 @@ export const CardRouter = () => {
             title,
             content,
             position,
-            dueDate,
+            dueDate: moment.tz(dueDate, 'Asia/Seoul').format(),
         });
         res.status(204).end();
     });

--- a/server/src/router/ListRouter.js
+++ b/server/src/router/ListRouter.js
@@ -1,3 +1,4 @@
+import moment from 'moment-timezone';
 import { Router } from 'express';
 import { ListService } from '../service/ListService';
 import { CardService } from '../service/CardService';
@@ -42,7 +43,10 @@ export const ListRouter = () => {
             dueDate: config.dueDate,
         });
 
-        const createdCard = await cardService.createCard(config);
+        const createdCard = await cardService.createCard({
+            ...config,
+            dueDate: moment.tz(config.dueDate, 'Asia/Seoul').format(),
+        });
         res.status(201).json(createdCard);
     });
 

--- a/server/src/service/BoardService.js
+++ b/server/src/service/BoardService.js
@@ -1,3 +1,4 @@
+import moment from 'moment-timezone';
 import { Transactional } from 'typeorm-transactional-cls-hooked';
 import { BaseService } from './BaseService';
 import { EntityNotFoundError } from '../common/error/EntityNotFoundError';
@@ -93,6 +94,12 @@ export class BoardService extends BaseService {
             boardDetail.invitedUsers = boardDetail.invitations.map((v) => v.user);
             delete boardDetail.invitations;
         }
+        boardDetail.lists.forEach((list) => {
+            list.cards.forEach((card) => {
+                // eslint-disable-next-line no-param-reassign
+                card.dueDate = moment(card.dueDate).tz('Asia/Seoul').format('YYYY-MM-DD HH:mm:ss');
+            });
+        });
         return boardDetail;
     }
 

--- a/server/src/service/CardService.js
+++ b/server/src/service/CardService.js
@@ -162,6 +162,7 @@ export class CardService extends BaseService {
             title: card.title,
             content: card.content,
             dueDate: moment(card.dueDate).tz('Asia/Seoul').format('YYYY-MM-DD HH:mm:ss'),
+            position: card.position,
             list: {
                 id: list.id,
                 title: list.title,

--- a/server/src/service/CardService.js
+++ b/server/src/service/CardService.js
@@ -133,6 +133,7 @@ export class CardService extends BaseService {
         await this.cardRepository.save(card);
     }
 
+    @Transactional()
     async getCard({ userId, cardId }) {
         const card = await this.customCardRepository.findWithListAndBoardById(cardId);
 
@@ -143,12 +144,12 @@ export class CardService extends BaseService {
         const { list } = card;
         const { board } = list;
 
-        const boardExisted = await this.customBoardRepository.existUserByBoardId({
+        const isAuthorized = await this.customBoardRepository.existUserByBoardId({
             boardId: board.id,
             userId,
         });
 
-        if (!boardExisted) {
+        if (!isAuthorized) {
             throw new ForbiddenError(`You're not invited`);
         }
 
@@ -160,8 +161,7 @@ export class CardService extends BaseService {
             id: card.id,
             title: card.title,
             content: card.content,
-            dueDate: moment(card.dueDate).tz('Asia/Seoul').format(),
-            position: card.position,
+            dueDate: moment(card.dueDate).tz('Asia/Seoul').format('YYYY-MM-DD HH:mm:ss'),
             list: {
                 id: list.id,
                 title: list.title,
@@ -178,7 +178,7 @@ export class CardService extends BaseService {
             comments: cardWithCommentsAndMembers.comments.map((comment) => ({
                 id: comment.id,
                 content: comment.content,
-                createdAt: moment(comment.createdAt).tz('Asia/Seoul').format(),
+                createdAt: moment(comment.createdAt).tz('Asia/Seoul').format('YYYY-MM-DD HH:mm:ss'),
                 user: {
                     id: comment.user.id,
                     name: comment.user.name,
@@ -214,11 +214,12 @@ export class CardService extends BaseService {
             creator: userId,
         });
         await this.cardRepository.save(card);
+
         return {
             id: card.id,
             title: card.title,
             position: card.position,
-            dueDate: card.dueDate,
+            dueDate: moment.tz(card.dueDate, 'Asia/Seoul').format('YYYY-MM-DD HH:mm:ss'),
             content: card.content,
         };
     }

--- a/server/src/service/CardService.js
+++ b/server/src/service/CardService.js
@@ -72,7 +72,7 @@ export class CardService extends BaseService {
             .map((card) => ({
                 id: card.id,
                 title: card.title,
-                dueDate: moment(card.dueDate).tz('Asia/Seoul').format(),
+                dueDate: moment(card.dueDate).tz('Asia/Seoul').format('YYYY-MM-DD HH:mm:ss'),
                 commentCount: card.commentCount,
             }));
     }
@@ -101,7 +101,7 @@ export class CardService extends BaseService {
         return cards.map((card) => ({
             id: card.id,
             title: card.title,
-            dueDate: moment(card.dueDate).tz('Asia/Seoul').format(),
+            dueDate: moment(card.dueDate).tz('Asia/Seoul').format('YYYY-MM-DD HH:mm:ss'),
             commentCount: card.commentCount,
         }));
     }

--- a/server/src/service/CommentService.js
+++ b/server/src/service/CommentService.js
@@ -1,3 +1,4 @@
+import moment from 'moment-timezone';
 import { Transactional } from 'typeorm-transactional-cls-hooked';
 import { EntityNotFoundError } from '../common/error/EntityNotFoundError';
 import { ForbiddenError } from '../common/error/ForbiddenError';
@@ -51,6 +52,7 @@ export class CommentService extends BaseService {
         return {
             id: comment.id,
             content: comment.content,
+            createdAt: moment(comment.createdAt).tz('Asia/Seoul').format('YYYY-MM-DD HH:mm:ss'),
             user: {
                 id: user.id,
                 name: user.name,
@@ -110,6 +112,7 @@ export class CommentService extends BaseService {
         return {
             id: comment.id,
             content: comment.content,
+            createdAt: moment(comment.createdAt).tz('Asia/Seoul').format('YYYY-MM-DD HH:mm:ss'),
             user: {
                 id: user.id,
                 name: user.name,

--- a/server/test/router/card/CardRouter.getCardByCardId.test.js
+++ b/server/test/router/card/CardRouter.getCardByCardId.test.js
@@ -189,7 +189,7 @@ describe('GET /api/card/:cardId', () => {
                 id: card0.id,
                 title: card0.title,
                 content: card0.content,
-                dueDate: card0.dueDate,
+                dueDate: moment(card0.dueDate).tz('Asia/Seoul').format('YYYY-MM-DD HH:mm:ss'),
                 position: card0.position,
                 list: {
                     id: list0.id,
@@ -212,7 +212,9 @@ describe('GET /api/card/:cardId', () => {
             expect(response.body.comments?.[0]).toEqual({
                 id: comment0.id,
                 content: comment0.content,
-                createdAt: moment(comment0.createdAt).tz('Asia/Seoul').format(),
+                createdAt: moment(comment0.createdAt)
+                    .tz('Asia/Seoul')
+                    .format('YYYY-MM-DD HH:mm:ss'),
                 user: {
                     id: user1.id,
                     name: user1.name,

--- a/server/test/router/card/CardRouter.getCardsByDueDate.test.js
+++ b/server/test/router/card/CardRouter.getCardsByDueDate.test.js
@@ -63,7 +63,7 @@ describe('GET /api/card?q=date: member:', () => {
                 title: 'card title 0',
                 content: 'card content 0',
                 position: 0,
-                dueDate: moment('2020-12-03T21:00:00').format(),
+                dueDate: moment.tz('2020-12-03T21:00:00', 'Asia/Seoul').format(),
                 list: list0,
                 creator: user0,
             });
@@ -71,7 +71,7 @@ describe('GET /api/card?q=date: member:', () => {
                 title: 'card title 1',
                 content: 'card content 1',
                 position: 10,
-                dueDate: moment('2020-12-03T22:00:00').format(),
+                dueDate: moment.tz('2020-12-03T22:00:00', 'Asia/Seoul').format(),
                 list: list0,
                 creator: user1,
             });
@@ -79,7 +79,7 @@ describe('GET /api/card?q=date: member:', () => {
                 title: 'card title 2',
                 content: 'card content 2',
                 position: 20,
-                dueDate: moment('2020-12-03T23:00:00').format(),
+                dueDate: moment.tz('2020-12-03T23:00:00', 'Asia/Seoul').format(),
                 list: list0,
                 creator: user1,
             });
@@ -103,7 +103,7 @@ describe('GET /api/card?q=date: member:', () => {
                 expect.objectContaining({
                     id: card0.id,
                     title: card0.title,
-                    dueDate: moment(card0.dueDate).tz('Asia/Seoul').format(),
+                    dueDate: moment(card0.dueDate).tz('Asia/Seoul').format('YYYY-MM-DD HH:mm:ss'),
                     commentCount: 0,
                 }),
             );
@@ -111,7 +111,7 @@ describe('GET /api/card?q=date: member:', () => {
                 expect.objectContaining({
                     id: card2.id,
                     title: card2.title,
-                    dueDate: moment(card2.dueDate).tz('Asia/Seoul').format(),
+                    dueDate: moment(card2.dueDate).tz('Asia/Seoul').format('YYYY-MM-DD HH:mm:ss'),
                     commentCount: 0,
                 }),
             );
@@ -187,7 +187,7 @@ describe('GET /api/card?q=date: member:', () => {
                 title: 'card title 0',
                 content: 'card content 0',
                 position: 0,
-                dueDate: moment('2020-12-03T09:37:00').format(),
+                dueDate: moment.tz('2020-12-03T09:37:00', 'Asia/Seoul').format(),
                 list: list0,
                 creator: user0,
             });
@@ -195,7 +195,7 @@ describe('GET /api/card?q=date: member:', () => {
                 title: 'card title 1',
                 content: 'card content 1',
                 position: 0,
-                dueDate: moment('2020-12-03T13:40:00').format(),
+                dueDate: moment.tz('2020-12-03T13:40:00', 'Asia/Seoul').format(),
                 list: list1,
                 creator: user1,
             });
@@ -203,7 +203,7 @@ describe('GET /api/card?q=date: member:', () => {
                 title: 'card title ',
                 content: 'card content 2',
                 position: 0,
-                dueDate: moment('2020-12-03T17:27:00').format(),
+                dueDate: moment.tz('2020-12-03T17:27:00', 'Asia/Seoul').format(),
                 list: list2,
                 creator: user1,
             });
@@ -211,7 +211,7 @@ describe('GET /api/card?q=date: member:', () => {
                 title: 'card title 3',
                 content: 'card content 3',
                 position: 10,
-                dueDate: moment('2020-12-03T18:59:00').format(),
+                dueDate: moment.tz('2020-12-03T18:59:00', 'Asia/Seoul').format(),
                 list: list2,
                 creator: user1,
             });
@@ -219,7 +219,7 @@ describe('GET /api/card?q=date: member:', () => {
                 title: 'card title 4',
                 content: 'card content 4',
                 position: 20,
-                dueDate: moment('2020-12-01T11:11:00').format(),
+                dueDate: moment.tz('2020-12-01T11:11:00', 'Asia/Seoul').format(),
                 list: list0,
                 creator: user1,
             });
@@ -241,7 +241,7 @@ describe('GET /api/card?q=date: member:', () => {
                 expect.objectContaining({
                     id: card0.id,
                     title: card0.title,
-                    dueDate: moment(card0.dueDate).tz('Asia/Seoul').format(),
+                    dueDate: moment(card0.dueDate).tz('Asia/Seoul').format('YYYY-MM-DD HH:mm:ss'),
                     commentCount: 0,
                 }),
             );
@@ -249,237 +249,7 @@ describe('GET /api/card?q=date: member:', () => {
                 expect.objectContaining({
                     id: card1.id,
                     title: card1.title,
-                    dueDate: moment(card1.dueDate).tz('Asia/Seoul').format(),
-                    commentCount: 0,
-                }),
-            );
-        });
-    });
-
-    test('GET /api/card?q=date:2020-12-03 member:me', async () => {
-        await TransactionRollbackExecutor.rollback(async () => {
-            const em = getEntityManagerOrTransactionManager('default');
-
-            const user0 = em.create(User, {
-                socialId: '0',
-                name: 'youngxpepp',
-                profileImageUrl: 'http://',
-            });
-            const user1 = em.create(User, {
-                socialId: '1',
-                name: 'dHoon',
-                profileImageUrl: 'http://',
-            });
-            await em.save([user0, user1]);
-
-            const board0 = em.create(Board, {
-                title: 'board title 0',
-                color: '#FFFFFF',
-                creator: user0,
-            });
-            await em.save(board0);
-
-            await em.save(em.create(Invitation, { user: user1, board: board0 }));
-
-            const list0 = em.create(List, {
-                title: 'list title 0',
-                position: 0,
-                board: board0,
-                creator: user0,
-            });
-            await em.save(list0);
-
-            const card0 = em.create(Card, {
-                title: 'card title 0',
-                content: 'card content 0',
-                position: 0,
-                dueDate: moment('2020-12-03T21:00:00').format(),
-                list: list0,
-                creator: user0,
-            });
-            const card1 = em.create(Card, {
-                title: 'card title 1',
-                content: 'card content 1',
-                position: 10,
-                dueDate: moment('2020-12-03T22:00:00').format(),
-                list: list0,
-                creator: user1,
-            });
-            const card2 = em.create(Card, {
-                title: 'card title 2',
-                content: 'card content 2',
-                position: 20,
-                dueDate: moment('2020-12-03T23:00:00').format(),
-                list: list0,
-                creator: user1,
-            });
-            await em.save([card0, card1, card2]);
-
-            await em.save([em.create(Member, { user: user0, card: card2 })]);
-
-            const accessToken = await jwtUtil.generateAccessToken({ userId: user0.id });
-
-            // when
-            const response = await agent(app.httpServer)
-                .get('/api/card')
-                .query({ q: `date:2020-12-03 member:me` })
-                .set('Authorization', accessToken)
-                .send();
-
-            // then
-            expect(response.status).toEqual(200);
-            expect(response.body.cards).toHaveLength(2);
-            expect(response.body.cards?.[0]).toEqual(
-                expect.objectContaining({
-                    id: card0.id,
-                    title: card0.title,
-                    dueDate: moment(card0.dueDate).tz('Asia/Seoul').format(),
-                    commentCount: 0,
-                }),
-            );
-            expect(response.body.cards?.[1]).toEqual(
-                expect.objectContaining({
-                    id: card2.id,
-                    title: card2.title,
-                    dueDate: moment(card2.dueDate).tz('Asia/Seoul').format(),
-                    commentCount: 0,
-                }),
-            );
-        });
-    });
-
-    test('GET /api/card?q=date:2020-12-03', async () => {
-        await TransactionRollbackExecutor.rollback(async () => {
-            // given
-            const em = getEntityManagerOrTransactionManager('default');
-
-            const user0 = em.create(User, {
-                socialId: '0',
-                name: 'youngxpepp',
-                profileImageUrl: 'http://',
-            });
-            const user1 = em.create(User, {
-                socialId: '1',
-                name: 'park-sooyeon',
-                profileImageUrl: 'http://',
-            });
-            await em.save([user0, user1]);
-
-            const board0 = em.create(Board, {
-                title: 'board title 0',
-                color: '#FFFFFF',
-                creator: user0,
-            });
-            const board1 = em.create(Board, {
-                title: 'board title 1',
-                color: '#FFFFFF',
-                creator: user1,
-            });
-            const board2 = em.create(Board, {
-                title: 'board title 1',
-                color: '#FFFFFF',
-                creator: user1,
-            });
-            await em.save([board0, board1, board2]);
-
-            await em.save([
-                em.create(Invitation, {
-                    user: user1,
-                    board: board0,
-                }),
-                em.create(Invitation, {
-                    user: user0,
-                    board: board1,
-                }),
-            ]);
-
-            const list0 = em.create(List, {
-                title: 'list title 0',
-                position: 0,
-                board: board0,
-                creator: user0,
-            });
-            const list1 = em.create(List, {
-                title: 'list title 0',
-                position: 0,
-                board: board1,
-                creator: user1,
-            });
-            const list2 = em.create(List, {
-                title: 'list title 0',
-                position: 0,
-                board: board2,
-                creator: user1,
-            });
-            await em.save([list0, list1, list2]);
-
-            const card0 = em.create(Card, {
-                title: 'card title 0',
-                content: 'card content 0',
-                position: 0,
-                dueDate: moment('2020-12-03T09:37:00').format(),
-                list: list0,
-                creator: user0,
-            });
-            const card1 = em.create(Card, {
-                title: 'card title 1',
-                content: 'card content 1',
-                position: 0,
-                dueDate: moment('2020-12-03T13:40:00').format(),
-                list: list1,
-                creator: user1,
-            });
-            const card2 = em.create(Card, {
-                title: 'card title ',
-                content: 'card content 2',
-                position: 0,
-                dueDate: moment('2020-12-03T17:27:00').format(),
-                list: list2,
-                creator: user1,
-            });
-            const card3 = em.create(Card, {
-                title: 'card title 3',
-                content: 'card content 3',
-                position: 10,
-                dueDate: moment('2020-12-03T18:59:00').format(),
-                list: list2,
-                creator: user1,
-            });
-            const card4 = em.create(Card, {
-                title: 'card title 4',
-                content: 'card content 4',
-                position: 20,
-                dueDate: moment('2020-12-01T11:11:00').format(),
-                list: list0,
-                creator: user1,
-            });
-            await em.save([card0, card1, card2, card3, card4]);
-
-            const accessToken = await jwtUtil.generateAccessToken({ userId: user0.id });
-
-            // when
-            const response = await agent(app.httpServer)
-                .get('/api/card')
-                .query({ q: `date:2020-12-03` })
-                .set('Authorization', accessToken)
-                .send();
-
-            // then
-            expect(response.status).toEqual(200);
-            expect(response.body.cards).toHaveLength(2);
-            expect(response.body.cards?.[0]).toEqual(
-                expect.objectContaining({
-                    id: card0.id,
-                    title: card0.title,
-                    dueDate: moment(card0.dueDate).tz('Asia/Seoul').format(),
-                    commentCount: 0,
-                }),
-            );
-            expect(response.body.cards?.[1]).toEqual(
-                expect.objectContaining({
-                    id: card1.id,
-                    title: card1.title,
-                    dueDate: moment(card1.dueDate).tz('Asia/Seoul').format(),
+                    dueDate: moment(card1.dueDate).tz('Asia/Seoul').format('YYYY-MM-DD HH:mm:ss'),
                     commentCount: 0,
                 }),
             );

--- a/server/test/router/comment/CommentRouter.patchCommentByCommentId.test.js
+++ b/server/test/router/comment/CommentRouter.patchCommentByCommentId.test.js
@@ -196,6 +196,7 @@ describe('PATCH /api/comment/:commentId', () => {
             expect(response.body).toEqual({
                 id: comment0.id,
                 content: expectedContent,
+                createdAt: expect.anything(),
                 user: {
                     id: user0.id,
                     name: user0.name,

--- a/server/test/router/list/ListRouter.postListCard.test.js
+++ b/server/test/router/list/ListRouter.postListCard.test.js
@@ -88,6 +88,13 @@ describe('POST /api/list/:listId/card', () => {
 
             // then
             expect(response.status).toEqual(201);
+            expect(response.body).toEqual({
+                id: expect.any(Number),
+                title: 'card title',
+                position: 1,
+                content: 'card detail',
+                dueDate: '2020-12-31 00:00:00',
+            });
         });
     });
 });

--- a/server/test/service/board/BoardService.getDetailBoard.test.js
+++ b/server/test/service/board/BoardService.getDetailBoard.test.js
@@ -1,3 +1,4 @@
+import moment from 'moment-timezone';
 import { getRepository } from 'typeorm';
 import { Application } from '../../../src/Application';
 import { Board } from '../../../src/model/Board';
@@ -53,7 +54,7 @@ describe('BoardService.getDetailBoard() Test', () => {
                 title: 'test card',
                 content: 'test content',
                 position: 1,
-                dueDate: '2020-01-01',
+                dueDate: moment.tz('2020-01-01', 'Asia/Seoul').format(),
                 list: createList.id,
                 creator: createUser.id,
             };
@@ -80,7 +81,7 @@ describe('BoardService.getDetailBoard() Test', () => {
                                 id: createCard.id,
                                 title: 'test card',
                                 position: 1,
-                                dueDate: '2020-01-01T00:00:00.000Z',
+                                dueDate: '2020-01-01 00:00:00',
                                 commentCount: 0,
                             },
                         ],

--- a/server/test/service/card/CardService.getCard.test.js
+++ b/server/test/service/card/CardService.getCard.test.js
@@ -170,7 +170,7 @@ describe('CardService.getCard() Test', () => {
                 id: card0.id,
                 title: card0.title,
                 content: card0.content,
-                dueDate: card0.dueDate,
+                dueDate: moment(card0.dueDate).tz('Asia/Seoul').format('YYYY-MM-DD HH:mm:ss'),
                 position: card0.position,
                 list: {
                     id: list0.id,
@@ -193,7 +193,9 @@ describe('CardService.getCard() Test', () => {
             expect(card.comments?.[0]).toEqual({
                 id: comment0.id,
                 content: comment0.content,
-                createdAt: moment(comment0.createdAt).tz('Asia/Seoul').format(),
+                createdAt: moment(comment0.createdAt)
+                    .tz('Asia/Seoul')
+                    .format('YYYY-MM-DD HH:mm:ss'),
                 user: {
                     id: user1.id,
                     name: user1.name,

--- a/server/test/service/card/CardService.getMyCardsByDueDate.test.js
+++ b/server/test/service/card/CardService.getMyCardsByDueDate.test.js
@@ -62,7 +62,7 @@ describe('CardService.getMyCardsByDueDate() Test', () => {
                 title: 'card title 0',
                 content: 'card content 0',
                 position: 0,
-                dueDate: moment('2020-12-03T21:00:00').format(),
+                dueDate: moment.tz('2020-12-03T21:00:00', 'Asia/Seoul').format(),
                 list: list0,
                 creator: user0,
             });
@@ -70,7 +70,7 @@ describe('CardService.getMyCardsByDueDate() Test', () => {
                 title: 'card title 1',
                 content: 'card content 1',
                 position: 10,
-                dueDate: moment('2020-12-03T22:00:00').format(),
+                dueDate: moment.tz('2020-12-03T22:00:00', 'Asia/Seoul').format(),
                 list: list0,
                 creator: user1,
             });
@@ -78,7 +78,7 @@ describe('CardService.getMyCardsByDueDate() Test', () => {
                 title: 'card title 2',
                 content: 'card content 2',
                 position: 20,
-                dueDate: moment('2020-12-03T23:00:00').format(),
+                dueDate: moment.tz('2020-12-03T23:00:00', 'Asia/Seoul').format(),
                 list: list0,
                 creator: user1,
             });

--- a/server/test/service/comment/CommentService.addComment.test.js
+++ b/server/test/service/comment/CommentService.addComment.test.js
@@ -173,6 +173,7 @@ describe('CommentService.addComment() Test', () => {
             expect(comment).toEqual({
                 id: expect.any(Number),
                 content: `edited card content 0`,
+                createdAt: expect.anything(),
                 user: {
                     id: user0.id,
                     name: user0.name,

--- a/server/test/service/comment/CommentService.modifyComment.test.js
+++ b/server/test/service/comment/CommentService.modifyComment.test.js
@@ -245,6 +245,7 @@ describe('CommentService.modifyComment() Test', () => {
             expect(commentResponseDto).toEqual({
                 id: commentRequestDto.id,
                 content: commentRequestDto.content,
+                createdAt: expect.anything(),
                 user: {
                     id: user0.id,
                     name: user0.name,


### PR DESCRIPTION
# 타임존 및 날짜 반환 형식 변경 완료

## 📎 해당 이슈

이슈 링크 (#266)

## 🛠 구현 내용 

- 데이터베이스 세션 타임존 한국 시간으로 변경
- 날짜 반환 형식 -> YYYY-MM-DD HH:mm:ss
- 댓글 생성/수정 API 응답에 댓글 생성 날짜 추가

## 🙋‍ 리뷰어 참고 사항 
- 날짜 반환 형식에서 HH와 hh가 차이가 있습니다. 전자는 0-24, 후자는 0-12라고 하네요 (https://momentjs.com/docs/)
- TypeORM에서 날짜를 DB에 저장할 때 날짜 문자열을 Date 타입으로 변경하는 과정이 있습니다. 이 과정에서 만약 날짜 문자열에 타임존 정보가 들어가 있지 않으면 UTC 기준으로 변경됩니다. 조심하세용
