### PR TITLE
댓글 수정 버튼 이슈

### DIFF
--- a/iOS/AreUDone/AreUDone/CalendarScene/View/Controller/CalendarViewController.swift
+++ b/iOS/AreUDone/AreUDone/CalendarScene/View/Controller/CalendarViewController.swift
@@ -162,6 +162,7 @@ extension CalendarViewController: DateStepperDelegate {
   }
   
   func dateLabelDidTapped(of dateString: String) {
+    tabBarController?.tabBar.isUserInteractionEnabled = false
     calendarCoordinator?.didTapOnDate(selectedDate: dateString.toDateFormat(withDividerFormat: .dot), delegate: self)
   }
 }
@@ -172,6 +173,7 @@ extension CalendarViewController: DateStepperDelegate {
 extension CalendarViewController: CalendarPickerViewControllerDelegate {
   
   func send(selectedDate: String) {
+    tabBarController?.tabBar.isUserInteractionEnabled = true
     viewModel.changeDate(to: selectedDate, direction: nil)
   }
 }

--- a/iOS/AreUDone/AreUDone/CardDetailScene/View/CollectionView/CommentCollectionViewCell.swift
+++ b/iOS/AreUDone/AreUDone/CardDetailScene/View/CollectionView/CommentCollectionViewCell.swift
@@ -83,6 +83,12 @@ final class CommentCollectionViewCell: UICollectionViewCell, Reusable {
   
   // MARK:- Method
   
+  override func prepareForReuse() {
+    super.prepareForReuse()
+    
+    editButton.isHidden = true
+  }
+  
   override func systemLayoutSizeFitting(
     _ targetSize: CGSize,
     withHorizontalFittingPriority horizontalFittingPriority: UILayoutPriority,


### PR DESCRIPTION
# 댓글 수정 버튼 이슈

## 📎 해당 이슈
#336 

## 🛠 구현 내용 

- 댓글을 다른 사람과 동시에 달았을 때 다른 사람의 댓글에 수정 버튼이 생기던 이슈 해결
- Calendar화면에서 달력이 나왔을 때 Tabbar가 활성화되어 Tab을 옮길 수 있었던 이슈 해결

## 🙋‍ 리뷰어 참고 사항 

