### PR TITLE
Comment 추가 후 response 처리하기

### DIFF
--- a/iOS/AreUDone/AreUDone/CardDetailScene/View/Controller/CardDetailViewController.swift
+++ b/iOS/AreUDone/AreUDone/CardDetailScene/View/Controller/CardDetailViewController.swift
@@ -259,6 +259,7 @@ private extension CardDetailViewController {
     bindingUpdateDueDateView()
     bindingUpdateContentView()
     bindingPrepareForUpdateMemberView()
+    bindingCreateComment()
   }
   
   func bindingCardDetailContentView() {
@@ -349,6 +350,18 @@ private extension CardDetailViewController {
       self.cardDetailCoordinator?.showMemberUpdate(with: cardId, boardId: boardId, cardMember: cardMembers, delegate: self)
     }
   }
+  
+  func bindingCreateComment() {
+    viewModel.bindingCreateComment { [weak self] updatedComment in
+      guard let self = self else { return }
+      var snapshot = self.dataSource.snapshot()
+      
+      DispatchQueue.main.async {
+        snapshot.appendItems([updatedComment])
+        self.dataSource.apply(snapshot)
+      }
+    }
+  }
 }
 
 
@@ -383,9 +396,7 @@ private extension CardDetailViewController {
 extension CardDetailViewController: CommentViewDelegate {
   
   func commentSaveButtonTapped(with comment: String) {
-    viewModel.addComment(with: comment) { [weak self] in
-      self?.viewModel.fetchDetailCard()
-    }
+    viewModel.addComment(with: comment)
   }
 }
 

--- a/iOS/AreUDone/AreUDone/CardDetailScene/ViewModel/CardDetailViewModel.swift
+++ b/iOS/AreUDone/AreUDone/CardDetailScene/ViewModel/CardDetailViewModel.swift
@@ -19,9 +19,10 @@ protocol CardDetailViewModelProtocol {
   func bindingUpdateDueDateView(handler: @escaping ((String) -> Void))
   func bindingUpdateContentView(handler: @escaping ((String) -> Void))
   func bindingPrepareForUpdateMemberView(handler: @escaping ((Int, Int, [User]?) -> Void))
+  func bindingCreateComment(handler: @escaping ((CardDetailComment) -> Void))
   
   func fetchDetailCard()
-  func addComment(with comment: String, completionHandler: @escaping (() -> Void))
+  func addComment(with comment: String)
   func updateDueDate(with dueDate: String)
   func updateContent(with content: String)
   func prepareUpdateMemberView()
@@ -51,6 +52,7 @@ final class CardDetailViewModel: CardDetailViewModelProtocol {
   private var commentViewProfileImageHandler: ((Data) -> Void)?
   private var cardDetailMemberViewHandler: (([User]?) -> Void)?
   private var prepareForUpdateMemberViewHandler: ((Int, Int, [User]?) -> Void)?
+  private var createCommentHandler: ((CardDetailComment) -> Void)?
   
   private let cache: NSCache<NSString, NSData> = NSCache()
   
@@ -98,11 +100,11 @@ final class CardDetailViewModel: CardDetailViewModelProtocol {
     }
   }
   
-  func addComment(with comment: String, completionHandler: @escaping (() -> Void)) {
+  func addComment(with comment: String) {
     commentService.createComment(with: id, content: comment) { result in
       switch result {
-      case .success(()):
-        completionHandler()
+      case .success((let updatedComment)):
+        self.createCommentHandler?(updatedComment)
         
       case .failure(let error):
         print(error)
@@ -240,5 +242,9 @@ extension CardDetailViewModel {
   
   func bindingPrepareForUpdateMemberView(handler: @escaping ((Int, Int, [User]?) -> Void)) {
     prepareForUpdateMemberViewHandler = handler
+  }
+  
+  func bindingCreateComment(handler: @escaping ((CardDetailComment) -> Void)) {
+    createCommentHandler = handler
   }
 }

--- a/iOS/AreUDone/AreUDone/Service/CommentService/CommentService.swift
+++ b/iOS/AreUDone/AreUDone/Service/CommentService/CommentService.swift
@@ -10,7 +10,7 @@ import NetworkFramework
 
 protocol CommentServiceProtocol {
   
-  func createComment(with cardId: Int, content: String, completionHandler: @escaping ((Result<Void, APIError>) -> Void))
+  func createComment(with cardId: Int, content: String, completionHandler: @escaping ((Result<CardDetailComment, APIError>) -> Void))
   func deleteComment(with commentId: Int, compeletionHandler: @escaping ((Result<Void, APIError>) -> Void))
 }
 
@@ -30,8 +30,8 @@ class CommentService: CommentServiceProtocol {
   
   // MARK: - Method
   
-  func createComment(with cardId: Int, content: String, completionHandler: @escaping ((Result<Void, APIError>) -> Void)) {
-    router.request(route: CommentEndPoint.createComment(cardId: cardId, content: content)) { (result: Result<Void, APIError>) in
+  func createComment(with cardId: Int, content: String, completionHandler: @escaping ((Result<CardDetailComment, APIError>) -> Void)) {
+    router.request(route: CommentEndPoint.createComment(cardId: cardId, content: content)) { (result: Result<CardDetailComment, APIError>) in
       completionHandler(result)
     }
   }


### PR DESCRIPTION
# Comment 추가 후 response 처리하기

## 📎 해당 이슈
#327 

## 🛠 구현 내용 
- Comment 추가 후 response 처리하기

## 🙋‍ 리뷰어 참고 사항 
response로 업데이트 된 comment를 받게되어 전체 데이터를 리프레쉬 해줄 필요가 없어졌습니다.
때문에 comment 추가 / 삭제 에 대해 realm에 반영하는 코드가 추가적으로 작성되야 할 것 같습니다.
그 부분은 따로 처리하도록 하겠습니다.
