### PR TITLE
비어 있는 View에 지시 UI 구현

### DIFF
--- a/iOS/AreUDone/AreUDone.xcodeproj/project.pbxproj
+++ b/iOS/AreUDone/AreUDone.xcodeproj/project.pbxproj
@@ -278,7 +278,6 @@
 		A84FC84E41C57DD915168344 /* Pods_AreUDoneTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E4C7872B0622973BAF08CBBF /* Pods_AreUDoneTests.framework */; };
 		BD088A952583A8840056E95D /* FetchBoardOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD088A942583A8840056E95D /* FetchBoardOption.swift */; };
 		BD088AB2258629690056E95D /* CardLocalDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD088AB1258629690056E95D /* CardLocalDataSource.swift */; };
-		BD088B242588A4900056E95D /* UIScrollView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD088B232588A4900056E95D /* UIScrollView+.swift */; };
 		BD088AD82588677C0056E95D /* NanumSquareBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 338364C825665CD900F92EE4 /* NanumSquareBold.ttf */; };
 		BD088AE125886B350056E95D /* SettingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD088AE025886B350056E95D /* SettingCoordinator.swift */; };
 		BD088AE925886B600056E95D /* Setting.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BD088AE825886B600056E95D /* Setting.storyboard */; };
@@ -286,6 +285,8 @@
 		BD088AF325886D4D0056E95D /* SettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD088AF225886D4D0056E95D /* SettingViewModel.swift */; };
 		BD088AFC258875510056E95D /* SettingTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD088AFB258875510056E95D /* SettingTableView.swift */; };
 		BD088B01258875FA0056E95D /* SettingTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD088B00258875FA0056E95D /* SettingTableViewCell.swift */; };
+		BD088B242588A4900056E95D /* UIScrollView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD088B232588A4900056E95D /* UIScrollView+.swift */; };
+		BD088B4E2589E5680056E95D /* EmptyIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD088B4D2589E5680056E95D /* EmptyIndicatorView.swift */; };
 		BD2AA727256CBE7600EA8791 /* CardCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2AA726256CBE7600EA8791 /* CardCollectionView.swift */; };
 		BD2AA72D256CBEB400EA8791 /* CardCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2AA72B256CBEB400EA8791 /* CardCollectionViewCell.swift */; };
 		BD2AA736256CC97200EA8791 /* CardContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2AA735256CC97200EA8791 /* CardContentView.swift */; };
@@ -549,13 +550,14 @@
 		B36B8C61E389093085BC5584 /* Pods-AreUDoneTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AreUDoneTests.release.xcconfig"; path = "Target Support Files/Pods-AreUDoneTests/Pods-AreUDoneTests.release.xcconfig"; sourceTree = "<group>"; };
 		BD088A942583A8840056E95D /* FetchBoardOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchBoardOption.swift; sourceTree = "<group>"; };
 		BD088AB1258629690056E95D /* CardLocalDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardLocalDataSource.swift; sourceTree = "<group>"; };
-		BD088B232588A4900056E95D /* UIScrollView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScrollView+.swift"; sourceTree = "<group>"; };
 		BD088AE025886B350056E95D /* SettingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingCoordinator.swift; sourceTree = "<group>"; };
 		BD088AE825886B600056E95D /* Setting.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Setting.storyboard; sourceTree = "<group>"; };
 		BD088AED25886B7A0056E95D /* SettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewController.swift; sourceTree = "<group>"; };
 		BD088AF225886D4D0056E95D /* SettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewModel.swift; sourceTree = "<group>"; };
 		BD088AFB258875510056E95D /* SettingTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingTableView.swift; sourceTree = "<group>"; };
 		BD088B00258875FA0056E95D /* SettingTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingTableViewCell.swift; sourceTree = "<group>"; };
+		BD088B232588A4900056E95D /* UIScrollView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScrollView+.swift"; sourceTree = "<group>"; };
+		BD088B4D2589E5680056E95D /* EmptyIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyIndicatorView.swift; sourceTree = "<group>"; };
 		BD2AA726256CBE7600EA8791 /* CardCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardCollectionView.swift; sourceTree = "<group>"; };
 		BD2AA72B256CBEB400EA8791 /* CardCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardCollectionViewCell.swift; sourceTree = "<group>"; };
 		BD2AA735256CC97200EA8791 /* CardContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardContentView.swift; sourceTree = "<group>"; };
@@ -680,6 +682,7 @@
 				333BA4F0257496B10057ACA4 /* CustomBarButtonItem.swift */,
 				BD2AA89A2574A2C000EA8791 /* PaddingLabel.swift */,
 				33F2D513257CB39A008F1E06 /* CustomSegmentControl.swift */,
+				BD088B4D2589E5680056E95D /* EmptyIndicatorView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -2050,6 +2053,7 @@
 				BD2AA80F256F8B6C00EA8791 /* CommentCollectionViewCell.swift in Sources */,
 				BDEA7BD82576246B00CF6B11 /* ContentInputViewController.swift in Sources */,
 				33F2D6CA257F838D008F1E06 /* ListTableViewDataSource.swift in Sources */,
+				BD088B4E2589E5680056E95D /* EmptyIndicatorView.swift in Sources */,
 				338317332581E0340040A467 /* CardAddTableView.swift in Sources */,
 				BDD18AC5256544C6005DF00A /* Coordinator.swift in Sources */,
 				BD59A683257E157000BF8928 /* MemberUpdateViewController.swift in Sources */,

--- a/iOS/AreUDone/AreUDone/BoardListScene/View/Controller/BoardListViewController.swift
+++ b/iOS/AreUDone/AreUDone/BoardListScene/View/Controller/BoardListViewController.swift
@@ -59,6 +59,13 @@ final class BoardListViewController: UIViewController {
     }
   }
   
+  private lazy var emptyIndicatorView: EmptyIndicatorView = {
+    let view = EmptyIndicatorView(emptyType: .boardEmpty)
+    view.translatesAutoresizingMaskIntoConstraints = false
+    
+    return view
+  }()
+  
   
   // MARK: - Initializer
   
@@ -101,8 +108,11 @@ final class BoardListViewController: UIViewController {
 private extension BoardListViewController {
   
   func configure() {
+    view.addSubview(emptyIndicatorView)
+    
     configureView()
     configureAddBoardButton()
+    configureEmptyIndicatorView()
   }
   
   func configureView() {
@@ -115,6 +125,13 @@ private extension BoardListViewController {
     let gestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(addBoardButtonTapped))
     addBoardButton.addGestureRecognizer(gestureRecognizer)
   }
+  
+  func configureEmptyIndicatorView() {
+    NSLayoutConstraint.activate([
+      emptyIndicatorView.centerXAnchor.constraint(equalTo: collectionView.centerXAnchor),
+      emptyIndicatorView.centerYAnchor.constraint(equalTo: collectionView.centerYAnchor)
+    ])
+  }
 }
 
 
@@ -125,6 +142,7 @@ private extension BoardListViewController {
   func bindUI() {
     bindingUpdateBoarListCollectionView()
     bindingDidBoardTapped()
+    bindingEmptyIndicatorView()
   }
   
   func bindingUpdateBoarListCollectionView() {
@@ -136,6 +154,14 @@ private extension BoardListViewController {
   func bindingDidBoardTapped() {
     viewModel.bindingDidBoardTapped { [weak self] boardId in
       self?.coordinator?.pushToBoardDetail(boardId: boardId)
+    }
+  }
+  
+  func bindingEmptyIndicatorView() {
+    viewModel.bindingEmptyIndicatorView { [weak self] isEmpty in
+      DispatchQueue.main.async {
+        self?.emptyIndicatorView.isHidden = isEmpty ? false : true
+      }
     }
   }
 }

--- a/iOS/AreUDone/AreUDone/BoardListScene/ViewModel/BoardListViewModel.swift
+++ b/iOS/AreUDone/AreUDone/BoardListScene/ViewModel/BoardListViewModel.swift
@@ -12,6 +12,7 @@ protocol BoardListViewModelProtocol {
   func bindingInitializeBoardListCollectionView(handler: @escaping ([Board]) -> Void)
   func bindingUpdateBoardListCollectionView(handler: @escaping ([Board]) -> Void)
   func bindingDidBoardTapped(handler: @escaping (Int) -> Void)
+  func bindingEmptyIndicatorView(handler: @escaping (Bool) -> Void)
   
   func fetchBoardId(for board: Board)
   func changeBoardOption(option: FetchBoardOption)
@@ -27,6 +28,7 @@ final class BoardListViewModel: BoardListViewModelProtocol {
   private var initializeBoardListCollectionViewHandler: (([Board]) -> Void)?
   private var updateBoardListCollectionViewHandler: (([Board]) -> Void)?
   private var didBoardTappedHandler: ((Int) -> Void)?
+  private var emptyIndicatorViewHandler: ((Bool) -> Void)?
   
   private var fetchBoardOption: FetchBoardOption = .myBoards {
     didSet {
@@ -86,5 +88,9 @@ extension BoardListViewModel {
   
   func bindingDidBoardTapped(handler: @escaping (Int) -> Void) {
     didBoardTappedHandler = handler
+  }
+  
+  func bindingEmptyIndicatorView(handler: @escaping (Bool) -> Void) {
+    emptyIndicatorViewHandler = handler
   }
 }

--- a/iOS/AreUDone/AreUDone/BoardListScene/ViewModel/BoardListViewModel.swift
+++ b/iOS/AreUDone/AreUDone/BoardListScene/ViewModel/BoardListViewModel.swift
@@ -62,8 +62,10 @@ final class BoardListViewModel: BoardListViewModelProtocol {
       case .success(let boards):
         if self.fetchBoardOption == .myBoards {
           self.updateBoardListCollectionViewHandler?(boards.fetchMyBoard())
+          self.emptyIndicatorViewHandler?(boards.fetchMyBoard().isEmpty)
         } else {
           self.updateBoardListCollectionViewHandler?(boards.fetchInvitedBoard())
+          self.emptyIndicatorViewHandler?(boards.fetchInvitedBoard().isEmpty)
         }
         
       case .failure(let error):

--- a/iOS/AreUDone/AreUDone/CalendarScene/View/Controller/CalendarViewController.swift
+++ b/iOS/AreUDone/AreUDone/CalendarScene/View/Controller/CalendarViewController.swift
@@ -223,8 +223,8 @@ extension CalendarViewController: CardCellDelegate {
       
       DispatchQueue.main.async {
         var snapshot = self.dataSource.snapshot()
-        
         snapshot.deleteItems([item])
+        self.viewModel.checkCardCollectionView(isEmpty: snapshot.itemIdentifiers.isEmpty)
         self.dataSource.apply(snapshot)
       }
     }

--- a/iOS/AreUDone/AreUDone/CalendarScene/View/Controller/CalendarViewController.swift
+++ b/iOS/AreUDone/AreUDone/CalendarScene/View/Controller/CalendarViewController.swift
@@ -52,6 +52,13 @@ final class CalendarViewController: UIViewController {
     }
   }
   
+  private lazy var emptyIndicatorView: EmptyIndicatorView = {
+    let view = EmptyIndicatorView(emptyType: .cardEmpty)
+    view.translatesAutoresizingMaskIntoConstraints = false
+    
+    return view
+  }()
+  
   
   // MARK: - Initializer
   
@@ -120,9 +127,22 @@ private extension CalendarViewController {
 private extension CalendarViewController {
   
   func configure() {
+    view.addSubview(emptyIndicatorView)
+    
     segmentedControl.delegate = self
     cardCollectionView.delegate = self
     dateStepper.delegate = self
+    
+    configureEmptyIndicatorView()
+  }
+  
+  func configureEmptyIndicatorView() {
+    NSLayoutConstraint.activate([
+      emptyIndicatorView.centerXAnchor.constraint(equalTo: cardCollectionView.centerXAnchor),
+      emptyIndicatorView.centerYAnchor.constraint(equalTo: cardCollectionView.centerYAnchor),
+      emptyIndicatorView.topAnchor.constraint(equalTo: cardCollectionView.topAnchor),
+      emptyIndicatorView.leadingAnchor.constraint(equalTo: cardCollectionView.leadingAnchor)
+    ])
   }
 }
 
@@ -134,6 +154,7 @@ private extension CalendarViewController {
   func bindUI() {
     bindingUpdateCardCollectionView()
     bindingUpdateDate()
+    bindingEmptyIndicatorView()
   }
   
   func bindingUpdateCardCollectionView() {
@@ -148,6 +169,14 @@ private extension CalendarViewController {
     viewModel.bindingUpdateDate { [weak self] date in
       DispatchQueue.main.async {
         self?.dateStepper.updateDate(date: date)
+      }
+    }
+  }
+  
+  func bindingEmptyIndicatorView() {
+    viewModel.bindingEmptyIndicatorView { [weak self] isEmpty in
+      DispatchQueue.main.async {
+        self?.emptyIndicatorView.isHidden = isEmpty ? false : true
       }
     }
   }

--- a/iOS/AreUDone/AreUDone/CalendarScene/ViewModel/CalendarViewModel.swift
+++ b/iOS/AreUDone/AreUDone/CalendarScene/ViewModel/CalendarViewModel.swift
@@ -17,6 +17,7 @@ protocol CalendarViewModelProtocol {
   func fetchDailyCards()
   func changeDate(to date: String, direction: Direction?)
   func deleteCard(for cardId: Int, completionHandler: @escaping () -> Void)
+  func checkCardCollectionView(isEmpty: Bool)
 }
 
 extension CalendarViewModelProtocol {
@@ -102,6 +103,10 @@ final class CalendarViewModel: CalendarViewModelProtocol {
         print(error)
       }
     }
+  }
+  
+  func checkCardCollectionView(isEmpty: Bool) {
+    emptyIndicatorViewHandler?(isEmpty)
   }
 }
 

--- a/iOS/AreUDone/AreUDone/CalendarScene/ViewModel/CalendarViewModel.swift
+++ b/iOS/AreUDone/AreUDone/CalendarScene/ViewModel/CalendarViewModel.swift
@@ -11,6 +11,7 @@ protocol CalendarViewModelProtocol {
   
   func bindingUpdateCardCollectionView(handler: @escaping (Cards) -> Void)
   func bindingUpdateDate(handler: @escaping (String) -> Void)
+  func bindingEmptyIndicatorView(handler: @escaping (Bool) -> Void)
   
   func fetchUpdateDailyCards(withOption option: FetchDailyCardsOption)
   func fetchDailyCards()
@@ -31,6 +32,7 @@ final class CalendarViewModel: CalendarViewModelProtocol {
   
   private var updateCardCollectionViewHandler: ((Cards) -> Void)?
   private var updateDateHandler: ((String) -> Void)?
+  private var emptyIndicatorViewHandler: ((Bool) -> Void)?
   
   private let cardService: CardServiceProtocol
   private var fetchDailyCardOption: FetchDailyCardsOption = .allCard {
@@ -93,6 +95,7 @@ final class CalendarViewModel: CalendarViewModelProtocol {
         //TODO: - self가 순환참조를 일으키는 확인해야 함.
         self.updateDateHandler?(self.selectedDate.toString())
         self.updateCardCollectionViewHandler?(cards)
+        self.emptyIndicatorViewHandler?(cards.cards.isEmpty)
       case .failure(let error):
         self.updateDateHandler?(self.selectedDate.toString())
         self.updateCardCollectionViewHandler?(Cards())
@@ -113,5 +116,9 @@ extension CalendarViewModel {
   
   func bindingUpdateDate(handler: @escaping (String) -> Void) {
     updateDateHandler = handler
+  }
+  
+  func bindingEmptyIndicatorView(handler: @escaping (Bool) -> Void) {
+    emptyIndicatorViewHandler = handler
   }
 }

--- a/iOS/AreUDone/AreUDone/CardDetailScene/View/Controller/CardDetailViewController.swift
+++ b/iOS/AreUDone/AreUDone/CardDetailScene/View/Controller/CardDetailViewController.swift
@@ -525,6 +525,9 @@ extension CardDetailViewController: CommentCollectionViewCellDelegate {
             snapshot.deleteItems([comment])
             self?.dataSource.apply(snapshot)
           }
+          DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
+            self?.viewModel.checkCommentCollectionView(isEmpty: snapshot.itemIdentifiers.isEmpty)
+          }
         }
       })
     

--- a/iOS/AreUDone/AreUDone/CardDetailScene/View/Controller/CardDetailViewController.swift
+++ b/iOS/AreUDone/AreUDone/CardDetailScene/View/Controller/CardDetailViewController.swift
@@ -67,6 +67,13 @@ final class CardDetailViewController: UIViewController {
     return view
   }()
   
+  private lazy var emptyIndicatorView: EmptyIndicatorView = {
+    let view = EmptyIndicatorView(emptyType: .commentEmpty)
+    view.translatesAutoresizingMaskIntoConstraints = false
+    
+    return view
+  }()
+  
   
   // MARK:- Initializer
   
@@ -181,6 +188,7 @@ private extension CardDetailViewController {
     scrollView.addSubview(stackView)
     stackView.addArrangedSubview(cardDetailMemberView)
     stackView.addArrangedSubview(commentCollectionView)
+    stackView.addArrangedSubview(emptyIndicatorView)
   }
   
   func configureScrollView() {
@@ -216,6 +224,12 @@ private extension CardDetailViewController {
       dummyViewForCommentView.widthAnchor.constraint(equalTo: view.widthAnchor),
       dummyViewForCommentView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
       dummyViewForCommentView.topAnchor.constraint(equalTo: commentView.bottomAnchor)
+    ])
+  }
+  
+  func configureEmptyIndicatorView() {
+    NSLayoutConstraint.activate([
+      emptyIndicatorView.widthAnchor.constraint(equalTo: stackView.widthAnchor)
     ])
   }
   
@@ -261,6 +275,7 @@ private extension CardDetailViewController {
     bindingPrepareForUpdateMemberView()
     bindingCreateComment()
     bindingCompleteAddComment()
+    bindingEmptyIndicatorView()
   }
   
   func bindingCardDetailContentView() {
@@ -370,6 +385,14 @@ private extension CardDetailViewController {
       self.viewModel.fetchDetailCard()
       DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
         self.scrollView.scrollToBottom()
+      }
+    }
+  }
+  
+  func bindingEmptyIndicatorView() {
+    viewModel.bindingEmptyIndicatorView { [weak self] isEmpty in
+      DispatchQueue.main.async {
+        self?.emptyIndicatorView.isHidden = isEmpty ? false : true
       }
     }
   }

--- a/iOS/AreUDone/AreUDone/CardDetailScene/ViewModel/CardDetailViewModel.swift
+++ b/iOS/AreUDone/AreUDone/CardDetailScene/ViewModel/CardDetailViewModel.swift
@@ -21,6 +21,7 @@ protocol CardDetailViewModelProtocol {
   func bindingPrepareForUpdateMemberView(handler: @escaping ((Int, Int, [User]?) -> Void))
   func bindingCreateComment(handler: @escaping ((CardDetailComment) -> Void))
   func bindingCompleteAddComment(handler: @escaping (() -> Void))
+  func bindingEmptyIndicatorView(handler: @escaping ((Bool) -> Void))
   
   func fetchDetailCard()
   func addComment(with comment: String)
@@ -55,6 +56,7 @@ final class CardDetailViewModel: CardDetailViewModelProtocol {
   private var prepareForUpdateMemberViewHandler: ((Int, Int, [User]?) -> Void)?
   private var createCommentHandler: ((CardDetailComment) -> Void)?
   private var completeAddCommentHandler: (() -> Void)?
+  private var emptyIndicatorViewHandler: ((Bool) -> Void)?
   
   private let cache: NSCache<NSString, NSData> = NSCache()
   
@@ -94,6 +96,7 @@ final class CardDetailViewModel: CardDetailViewModelProtocol {
         self?.cardDetailListTitleHandler?(detailCard.list!.title)
         self?.cardDetailBoardTitleHandler?(detailCard.board!.title)
         self?.cardDetailMemberViewHandler?(detailCard.fetchMembers())
+        self?.emptyIndicatorViewHandler?(detailCard.comments.isEmpty)
         self?.fetchUserData()
         
       case .failure(let error):
@@ -250,7 +253,12 @@ extension CardDetailViewModel {
   func bindingCreateComment(handler: @escaping ((CardDetailComment) -> Void)) {
     createCommentHandler = handler
   }
+  
   func bindingCompleteAddComment(handler: @escaping (() -> Void)) {
     completeAddCommentHandler = handler
+  }
+  
+  func bindingEmptyIndicatorView(handler: @escaping ((Bool) -> Void)) {
+    emptyIndicatorViewHandler = handler
   }
 }

--- a/iOS/AreUDone/AreUDone/CardDetailScene/ViewModel/CardDetailViewModel.swift
+++ b/iOS/AreUDone/AreUDone/CardDetailScene/ViewModel/CardDetailViewModel.swift
@@ -31,6 +31,7 @@ protocol CardDetailViewModelProtocol {
   func prepareUpdateCell(handler: (Int) -> Void)
   func deleteComment(with commentId: Int, completionHandler: @escaping () -> Void)
   func fetchProfileImage(with urlAsString: String, userName: String, completionHandler: @escaping ((Data) -> Void))
+  func checkCommentCollectionView(isEmpty: Bool)
 }
 
 final class CardDetailViewModel: CardDetailViewModelProtocol {
@@ -180,6 +181,10 @@ final class CardDetailViewModel: CardDetailViewModelProtocol {
         print(error)
       }
     }
+  }
+  
+  func checkCommentCollectionView(isEmpty: Bool) {
+    self.emptyIndicatorViewHandler?(isEmpty)
   }
   
   private func fetchUserData() {

--- a/iOS/AreUDone/AreUDone/Common/View/EmptyIndicatorView.swift
+++ b/iOS/AreUDone/AreUDone/Common/View/EmptyIndicatorView.swift
@@ -1,0 +1,69 @@
+//
+//  EmptyIndicatorView.swift
+//  AreUDone
+//
+//  Created by 서명렬 on 2020/12/16.
+//
+
+import UIKit
+
+enum EmptyType {
+  case cardEmpty
+  case boardEmpty
+  case commentEmpty
+  
+  var emptyIndicatorText: String {
+    switch self {
+    case .cardEmpty:
+      return "보드에서 카드를 생성해보세요🔖🗂"
+      
+    case .boardEmpty:
+      return "보드를 생성해보세요📝"
+      
+    case .commentEmpty:
+      return "첫 번째 댓글을 달아주세요😭"
+    }
+  }
+}
+
+final class EmptyIndicatorView: UIView {
+
+  // MARK:- Property
+  
+  private lazy var emptyIndicatorLabel: UILabel = {
+    let label = UILabel()
+    label.translatesAutoresizingMaskIntoConstraints = false
+    label.numberOfLines = 0
+    label.font = UIFont.nanumB(size: 20)
+    
+    return label
+  }()
+  
+  
+  convenience init(emptyType: EmptyType) {
+    self.init()
+    
+    emptyIndicatorLabel.text = emptyType.emptyIndicatorText
+    configure()
+  }
+}
+
+
+// MARK:- Extension Configure Method
+
+private extension EmptyIndicatorView {
+  
+  func configure() {
+    isHidden = true
+    addSubview(emptyIndicatorLabel)
+    
+    configureEmptyIndicatorLabel()
+  }
+  
+  func configureEmptyIndicatorLabel() {
+    NSLayoutConstraint.activate([
+      emptyIndicatorLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
+      emptyIndicatorLabel.centerYAnchor.constraint(equalTo: centerYAnchor)
+    ])
+  }
+}


### PR DESCRIPTION
# 비어 있는 View에 지시 UI 구현

## 📎 해당 이슈
#346 

## 🛠 구현 내용 

- Calendar 화면의 카드가 비어 있는 경우 지시 UI를 통해 사용자에게 카드 생성 유도
- Board 화면의 board가 비어 있는 경우 지시 UI를 통해 사용자에게 보드 생성 유도
- 댓글이 비어 있는 경우 지시 UI를 통해 댓글 생성 유도


## 🙋‍ 리뷰어 참고 사항 
없습니다.
