### PR TITLE
오프라인에서 보드 목록 추가 시 Realm 에 EndPoint 및 보드 정보 저장

### DIFF
--- a/iOS/AreUDone/AreUDone.xcodeproj/project.pbxproj
+++ b/iOS/AreUDone/AreUDone.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		3344375B2588F53C0077DEC7 /* ListTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3344375A2588F53C0077DEC7 /* ListTableView.swift */; };
 		334437732589CD010077DEC7 /* EndPointable+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 334437722589CD010077DEC7 /* EndPointable+.swift */; };
 		334437782589CEFA0077DEC7 /* OrderedEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 334437772589CEFA0077DEC7 /* OrderedEndPoint.swift */; };
+		3344377D2589D1D70077DEC7 /* NWMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3344377C2589D1D70077DEC7 /* NWMonitor.swift */; };
 		335AC4AF256E9A6B006A5C4A /* Board.swift in Sources */ = {isa = PBXBuildFile; fileRef = 335AC4AE256E9A6B006A5C4A /* Board.swift */; };
 		335AC4B4256EA1BB006A5C4A /* BoardListCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 335AC4B3256EA1BB006A5C4A /* BoardListCollectionViewCell.swift */; };
 		335AC4B9256EA1EA006A5C4A /* BoardListCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 335AC4B8256EA1EA006A5C4A /* BoardListCollectionView.swift */; };
@@ -163,6 +164,8 @@
 		33C3FB9D258525AE006DB60B /* RealmBoardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33C3FB9C258525AE006DB60B /* RealmBoardTests.swift */; };
 		33C3FBAE2585F681006DB60B /* BoardLocalDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33C3FBAD2585F681006DB60B /* BoardLocalDataSource.swift */; };
 		33C3FBB325862F01006DB60B /* Realm+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33C3FBB225862F01006DB60B /* Realm+.swift */; };
+		33C494AB2589FF5A0095DE39 /* BorderLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33C494AA2589FF5A0095DE39 /* BorderLayer.swift */; };
+		33C494B0258A01650095DE39 /* ScreenBorderLayerAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33C494AF258A01650095DE39 /* ScreenBorderLayerAnimator.swift */; };
 		33D2DE1C256B51CE008E3969 /* MockRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33D2DE1B256B51CE008E3969 /* MockRouter.swift */; };
 		33D2DE21256B5210008E3969 /* JsonFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33D2DE20256B5210008E3969 /* JsonFactory.swift */; };
 		33EE01662568DFF6003D3221 /* TabbarCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33EE01652568DFF6003D3221 /* TabbarCoordinator.swift */; };
@@ -424,6 +427,7 @@
 		3344375A2588F53C0077DEC7 /* ListTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListTableView.swift; sourceTree = "<group>"; };
 		334437722589CD010077DEC7 /* EndPointable+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EndPointable+.swift"; sourceTree = "<group>"; };
 		334437772589CEFA0077DEC7 /* OrderedEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderedEndPoint.swift; sourceTree = "<group>"; };
+		3344377C2589D1D70077DEC7 /* NWMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NWMonitor.swift; sourceTree = "<group>"; };
 		335AC4AE256E9A6B006A5C4A /* Board.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Board.swift; sourceTree = "<group>"; };
 		335AC4B3256EA1BB006A5C4A /* BoardListCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardListCollectionViewCell.swift; sourceTree = "<group>"; };
 		335AC4B8256EA1EA006A5C4A /* BoardListCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardListCollectionView.swift; sourceTree = "<group>"; };
@@ -506,6 +510,8 @@
 		33C3FB9C258525AE006DB60B /* RealmBoardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealmBoardTests.swift; sourceTree = "<group>"; };
 		33C3FBAD2585F681006DB60B /* BoardLocalDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardLocalDataSource.swift; sourceTree = "<group>"; };
 		33C3FBB225862F01006DB60B /* Realm+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Realm+.swift"; sourceTree = "<group>"; };
+		33C494AA2589FF5A0095DE39 /* BorderLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BorderLayer.swift; sourceTree = "<group>"; };
+		33C494AF258A01650095DE39 /* ScreenBorderLayerAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenBorderLayerAnimator.swift; sourceTree = "<group>"; };
 		33D2DE1B256B51CE008E3969 /* MockRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRouter.swift; sourceTree = "<group>"; };
 		33D2DE20256B5210008E3969 /* JsonFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JsonFactory.swift; sourceTree = "<group>"; };
 		33EE01652568DFF6003D3221 /* TabbarCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabbarCoordinator.swift; sourceTree = "<group>"; };
@@ -682,6 +688,7 @@
 				333BA4F0257496B10057ACA4 /* CustomBarButtonItem.swift */,
 				BD2AA89A2574A2C000EA8791 /* PaddingLabel.swift */,
 				33F2D513257CB39A008F1E06 /* CustomSegmentControl.swift */,
+				33C494AA2589FF5A0095DE39 /* BorderLayer.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1164,6 +1171,8 @@
 				3360124E256E58F7009580A1 /* TabbarItemContentsFactory.swift */,
 				BDD18B0A2566132A005DF00A /* Keychain.swift */,
 				BDEA7BEA2576385000CF6B11 /* AlertFactory.swift */,
+				3344377C2589D1D70077DEC7 /* NWMonitor.swift */,
+				33C494AF258A01650095DE39 /* ScreenBorderLayerAnimator.swift */,
 				BDE27E30256B9335002308B9 /* Protocol */,
 				336010DC256B8E34009580A1 /* Mock */,
 				BDD18BB22568D636005DF00A /* Constants */,
@@ -2057,6 +2066,7 @@
 				BDD18AC5256544C6005DF00A /* Coordinator.swift in Sources */,
 				BD59A683257E157000BF8928 /* MemberUpdateViewController.swift in Sources */,
 				BD2AA7A1256DF8E400EA8791 /* CardDetailViewController.swift in Sources */,
+				3344377D2589D1D70077DEC7 /* NWMonitor.swift in Sources */,
 				BD2AA7C3256E3D3600EA8791 /* CardDetail.swift in Sources */,
 				3373A49A2578DEC300D92CC0 /* MemberFooterView.swift in Sources */,
 				335AC4E6256F7988006A5C4A /* BoardListJsonFactory.swift in Sources */,
@@ -2179,12 +2189,14 @@
 				BD2AA727256CBE7600EA8791 /* CardCollectionView.swift in Sources */,
 				333BA53B2575FFCC0057ACA4 /* SideBarViewController.swift in Sources */,
 				BD088AF325886D4D0056E95D /* SettingViewModel.swift in Sources */,
+				33C494AB2589FF5A0095DE39 /* BorderLayer.swift in Sources */,
 				BD59A701257F7A2A00BF8928 /* MonthCardCount.swift in Sources */,
 				335AC4B4256EA1BB006A5C4A /* BoardListCollectionViewCell.swift in Sources */,
 				333BA5CF25787F290057ACA4 /* ImageService.swift in Sources */,
 				33F2D508257B6AFE008F1E06 /* InvitationTableViewDataSource.swift in Sources */,
 				333BA5D825787FC40057ACA4 /* ImageEndPoint.swift in Sources */,
 				BD088AE125886B350056E95D /* SettingCoordinator.swift in Sources */,
+				33C494B0258A01650095DE39 /* ScreenBorderLayerAnimator.swift in Sources */,
 				BDEA7BE3257627E100CF6B11 /* ContentInputCoordinator.swift in Sources */,
 				BD2AA8D82575FFB500EA8791 /* CardDetailLocationView.swift in Sources */,
 				338317402581E21E0040A467 /* CardAddCalendarTableViewCell.swift in Sources */,

--- a/iOS/AreUDone/AreUDone.xcodeproj/project.pbxproj
+++ b/iOS/AreUDone/AreUDone.xcodeproj/project.pbxproj
@@ -30,6 +30,8 @@
 		333BA5CF25787F290057ACA4 /* ImageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 333BA5CE25787F290057ACA4 /* ImageService.swift */; };
 		333BA5D825787FC40057ACA4 /* ImageEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 333BA5D725787FC40057ACA4 /* ImageEndPoint.swift */; };
 		3344375B2588F53C0077DEC7 /* ListTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3344375A2588F53C0077DEC7 /* ListTableView.swift */; };
+		334437732589CD010077DEC7 /* EndPointable+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 334437722589CD010077DEC7 /* EndPointable+.swift */; };
+		334437782589CEFA0077DEC7 /* OrderedEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 334437772589CEFA0077DEC7 /* OrderedEndPoint.swift */; };
 		335AC4AF256E9A6B006A5C4A /* Board.swift in Sources */ = {isa = PBXBuildFile; fileRef = 335AC4AE256E9A6B006A5C4A /* Board.swift */; };
 		335AC4B4256EA1BB006A5C4A /* BoardListCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 335AC4B3256EA1BB006A5C4A /* BoardListCollectionViewCell.swift */; };
 		335AC4B9256EA1EA006A5C4A /* BoardListCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 335AC4B8256EA1EA006A5C4A /* BoardListCollectionView.swift */; };
@@ -420,6 +422,8 @@
 		333BA5CE25787F290057ACA4 /* ImageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageService.swift; sourceTree = "<group>"; };
 		333BA5D725787FC40057ACA4 /* ImageEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageEndPoint.swift; sourceTree = "<group>"; };
 		3344375A2588F53C0077DEC7 /* ListTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListTableView.swift; sourceTree = "<group>"; };
+		334437722589CD010077DEC7 /* EndPointable+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EndPointable+.swift"; sourceTree = "<group>"; };
+		334437772589CEFA0077DEC7 /* OrderedEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderedEndPoint.swift; sourceTree = "<group>"; };
 		335AC4AE256E9A6B006A5C4A /* Board.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Board.swift; sourceTree = "<group>"; };
 		335AC4B3256EA1BB006A5C4A /* BoardListCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardListCollectionViewCell.swift; sourceTree = "<group>"; };
 		335AC4B8256EA1EA006A5C4A /* BoardListCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardListCollectionView.swift; sourceTree = "<group>"; };
@@ -1503,6 +1507,7 @@
 				BD59A6CB257F180100BF8928 /* TokenParser.swift */,
 				BD59A6D0257F192300BF8928 /* UserIdStore.swift */,
 				BD59A700257F7A2A00BF8928 /* MonthCardCount.swift */,
+				334437772589CEFA0077DEC7 /* OrderedEndPoint.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -1576,6 +1581,7 @@
 				3373A4942578DC7200D92CC0 /* UIView+.swift */,
 				338316F1258078900040A467 /* NotificationName+.swift */,
 				33C3FBB225862F01006DB60B /* Realm+.swift */,
+				334437722589CD010077DEC7 /* EndPointable+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -2147,6 +2153,8 @@
 				33F2D6C5257F7D9F008F1E06 /* BoardDetailCollectionViewDataSource.swift in Sources */,
 				3360124F256E58F7009580A1 /* TabbarItemContentsFactory.swift in Sources */,
 				BD59A6D1257F192300BF8928 /* UserIdStore.swift in Sources */,
+				334437782589CEFA0077DEC7 /* OrderedEndPoint.swift in Sources */,
+				334437732589CD010077DEC7 /* EndPointable+.swift in Sources */,
 				33EE01802568EE7E003D3221 /* CalendarCoordinator.swift in Sources */,
 				336010C8256B78CE009580A1 /* CardEndPoint.swift in Sources */,
 				3383175225820C2B0040A467 /* CardAddContentsTableViewCell.swift in Sources */,

--- a/iOS/AreUDone/AreUDone/BoardAddScene/BoardAddCoordinator.swift
+++ b/iOS/AreUDone/AreUDone/BoardAddScene/BoardAddCoordinator.swift
@@ -35,7 +35,7 @@ final class BoardAddCoordinator: NavigationCoordinator {
             identifier: BoardAddViewController.identifier, creator: { [weak self] coder in
               guard let self = self else { return UIViewController() }
               
-              let boardService = BoardService(router: self.router)
+              let boardService = BoardService(router: self.router, localDataSource: BoardLocalDataSource())
               let viewModel = BoardAddViewModel(boardService: boardService)
               return BoardAddViewController(coder: coder, viewModel: viewModel)
             }) as? BoardAddViewController else { return UIViewController() }

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/ViewModel/BoardDetailViewModel.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/ViewModel/BoardDetailViewModel.swift
@@ -80,7 +80,8 @@ final class BoardDetailViewModel: BoardDetailViewModelProtocol {
   // MARK: - Method
   
   func save() {
-    realm.writeOnMain(object: boardDetail!) { object in
+    guard let boardDetail = boardDetail else { return }
+    realm.writeOnMain(object: boardDetail) { object in
       self.realm.create(BoardDetail.self, value: object, update: .all)
     }
   }

--- a/iOS/AreUDone/AreUDone/Common/Coordinator/SceneCoordinator.swift
+++ b/iOS/AreUDone/AreUDone/Common/Coordinator/SceneCoordinator.swift
@@ -16,14 +16,15 @@ final class SceneCoordinator: Coordinator {
   private var window: UIWindow?
   private let initCoordinatorFactory: CoordinatorFactoryable
   private let signinChecker: SigninCheckable
-  private let router: Router
+  private let router: Routable
   private var initCoordinator: Coordinator!
+  
   
   // MARK: - Initializer
   
   init(
     window: UIWindow?,
-    router: Router,
+    router: Routable,
     factory: CoordinatorFactoryable,
     signinChecker: SigninCheckable
   ) {
@@ -37,6 +38,7 @@ final class SceneCoordinator: Coordinator {
   // MARK: - Method
   
   func start() -> UIViewController {
+    
     let signinCheckResult = signinChecker.check()
     
     initCoordinator = initCoordinatorFactory.coordinator(

--- a/iOS/AreUDone/AreUDone/Common/Extension/EndPointable+.swift
+++ b/iOS/AreUDone/AreUDone/Common/Extension/EndPointable+.swift
@@ -1,0 +1,34 @@
+//
+//  EndPointable+.swift
+//  AreUDone
+//
+//  Created by a1111 on 2020/12/16.
+//
+
+import Foundation
+import NetworkFramework
+
+extension EndPointable {
+  
+  func toDictionary() -> [String: Any] {
+    let headers = makeRealmKeyValue(dictionary: self.headers)
+    let bodies = makeRealmKeyValue(dictionary: self.bodies)
+    let queries = makeRealmKeyValue(dictionary: self.query)
+
+    let dic: [String: Any] = [
+      "environmentBaseURL": self.environmentBaseURL,
+      "httpMethodRawValue": self.httpMethod?.rawValue as Any,
+      "headersList": headers as Any,
+      "bodiesList": bodies as Any,
+      "queryList": queries as Any
+    ]
+    
+    return dic
+  }
+  
+  private func makeRealmKeyValue(dictionary: [String: Any]?) -> [[String: Any]]? {
+    return dictionary?.map { (key, value) in
+      ["key": key, "value": value]
+    }
+  }
+}

--- a/iOS/AreUDone/AreUDone/Common/Extension/NotificationName+.swift
+++ b/iOS/AreUDone/AreUDone/Common/Extension/NotificationName+.swift
@@ -11,4 +11,5 @@ extension Notification.Name {
   
   static let listWillDragged = Notification.Name("ListWillDragged")
   static let listDidDragged = Notification.Name("ListDidDragged")
+  static let networkChanged = Notification.Name("networkChanged")
 }

--- a/iOS/AreUDone/AreUDone/Common/Model/Board.swift
+++ b/iOS/AreUDone/AreUDone/Common/Model/Board.swift
@@ -9,8 +9,13 @@ import Foundation
 import RealmSwift
 
 class Boards: Object, Codable {
+  @objc dynamic var id: Int = 0
   var myBoards = List<Board>()
   var invitedBoards = List<Board>()
+  
+  override class func primaryKey() -> String? {
+    return "id"
+  }
   
   required convenience init(from decoder: Decoder) throws {
     self.init()
@@ -35,9 +40,13 @@ class Boards: Object, Codable {
 }
 
 class Board: Object, Codable {
-  @objc dynamic var id: Int = 0
+  @objc dynamic var id: Int = UUID().hashValue
   @objc dynamic var title: String = ""
   @objc dynamic var color: String = ""
+  
+  override class func primaryKey() -> String? {
+    return "id"
+  }
 }
 
 

--- a/iOS/AreUDone/AreUDone/Common/Model/OrderedEndPoint.swift
+++ b/iOS/AreUDone/AreUDone/Common/Model/OrderedEndPoint.swift
@@ -1,0 +1,57 @@
+//
+//  OrderedEndPoint.swift
+//  AreUDone
+//
+//  Created by a1111 on 2020/12/16.
+//
+
+import Foundation
+import NetworkFramework
+import RealmSwift
+
+class OrderedEndPoint: Object, EndPointable {
+  @objc dynamic var date: Date = Date()
+  
+  var httpMethod: HTTPMethod? {
+    return HTTPMethod(rawValue: httpMethodRawValue)
+  }
+  var headers: HTTPHeader? {
+    var headers = [String: String]() // TODO: 메소드로 모듈화해보기
+    Array(headersList).forEach {
+      headers[$0.key] = $0.value
+    }
+    
+    return headers
+  }
+  var bodies: HTTPBody? {
+    var bodies = [String: Any]()
+    Array(bodiesList).forEach {
+      bodies[$0.key] = $0.value
+    }
+    
+    return bodies
+  }
+  var query: HTTPQuery? {
+    var queries = [String: String]()
+    Array(queryList).forEach {
+      queries[$0.key] = $0.value
+    }
+    
+    return queries
+  }
+  var baseURL: URLComponents {
+    guard let url = URLComponents(string: environmentBaseURL) else { fatalError() } // TODO: 예외처리로 바꿔주기
+    return url
+  }
+  
+  @objc dynamic var environmentBaseURL: String = ""
+  @objc dynamic var httpMethodRawValue: String = ""
+  var headersList = List<dic>()
+  var bodiesList = List<dic>()
+  var queryList = List<dic>()
+}
+
+class dic: Object {
+  @objc dynamic var key: String = ""
+  @objc dynamic var value: String = ""
+}

--- a/iOS/AreUDone/AreUDone/Common/NWMonitor.swift
+++ b/iOS/AreUDone/AreUDone/Common/NWMonitor.swift
@@ -1,0 +1,95 @@
+//
+//  NWMonitor.swift
+//  AreUDone
+//
+//  Created by a1111 on 2020/12/16.
+//
+
+import Foundation
+import Network
+import NetworkFramework
+import RealmSwift
+
+final class NWMonitor {
+  
+  // MARK: - Property
+  
+  let semaphore = DispatchSemaphore(value: 1)
+  let monitor = NWPathMonitor()
+  let router: Routable
+  
+  var currentState: NWPath.Status!
+  
+  
+  // MARK: - Initializer
+  
+  init(router: Routable) {
+    self.router = router
+    
+    configure()
+  }
+  
+  func start() {
+    let queue = DispatchQueue.global(qos: .background)
+    monitor.start(queue: queue)
+  }
+}
+
+
+// MARK: - Extension Configure Method
+
+private extension NWMonitor {
+  
+  func configure() {
+    monitor.pathUpdateHandler = { path in
+      
+      if path.status == .satisfied {
+        guard self.currentState != .satisfied else { return }
+        
+        NotificationCenter.default.post(
+          name: Notification.Name.networkChanged,
+          object: nil,
+          userInfo: ["networkState": true]
+        )
+        
+        self.storedEndPoints()
+      } else {
+        guard self.currentState != .unsatisfied else { return }
+        
+        NotificationCenter.default.post(
+          name: Notification.Name.networkChanged,
+          object: nil,
+          userInfo: ["networkState": false]
+        )
+      }
+      
+      self.currentState = path.status
+    }
+  }
+  
+  func storedEndPoints() {
+    let realm = try! Realm()
+    let result = realm.objects(OrderedEndPoint.self).sorted(byKeyPath: "date")
+    let endPoints = Array(result)
+    
+    endPoints.forEach { endPoint in
+      semaphore.wait()
+     
+      router.request(route: endPoint) { result in
+        switch result {
+        case .success(_):
+          break
+          
+        case .failure(let error):
+          print(error)
+        }
+
+        self.semaphore.signal()
+      }
+    }
+    
+    try! realm.write {
+      realm.delete(result)
+    }
+  }
+}

--- a/iOS/AreUDone/AreUDone/Common/ScreenBorderLayerAnimator.swift
+++ b/iOS/AreUDone/AreUDone/Common/ScreenBorderLayerAnimator.swift
@@ -1,0 +1,51 @@
+//
+//  ScreenBorderLayerAnimator.swift
+//  AreUDone
+//
+//  Created by a1111 on 2020/12/16.
+//
+
+import UIKit
+
+final class ScreenBorderAlertAnimator {
+  
+  // MARK: - Property
+  
+  let borderLayer: CALayer
+  
+  
+  // MARK: - Initializer
+  
+  init(borderLayer: CALayer) {
+    self.borderLayer = borderLayer
+  }
+  
+  
+  // MARK: - Method
+  
+  func start(networkState: Bool) {
+    let color: CGColor
+    
+    if networkState { color = UIColor.systemGreen.cgColor
+    } else { color = UIColor.systemRed.cgColor }
+    
+    let widthAnimation = CABasicAnimation(keyPath: "borderWidth")
+    widthAnimation.fromValue = 0
+    widthAnimation.toValue = 9
+    
+    let colorAnimation = CABasicAnimation(keyPath: "borderColor")
+    colorAnimation.fromValue = UIColor.systemOrange.cgColor
+    colorAnimation.toValue = color
+    
+    let bothAnimations = CAAnimationGroup()
+    bothAnimations.duration = 3
+    bothAnimations.autoreverses = true
+    bothAnimations.animations = [colorAnimation, widthAnimation]
+    bothAnimations.timingFunction = CAMediaTimingFunction(
+      name: CAMediaTimingFunctionName.easeInEaseOut
+    )
+    bothAnimations.repeatCount = 2
+    bothAnimations.speed = 2
+    borderLayer.add(bothAnimations, forKey: "networkAlert")
+  }
+}

--- a/iOS/AreUDone/AreUDone/Common/View/BorderLayer.swift
+++ b/iOS/AreUDone/AreUDone/Common/View/BorderLayer.swift
@@ -1,0 +1,40 @@
+//
+//  BorderLayer.swift
+//  AreUDone
+//
+//  Created by a1111 on 2020/12/16.
+//
+
+import UIKit
+
+final class BorderLayer: CALayer {
+  
+  // MARK: - Initializer
+  
+  override init() {
+    super.init()
+  }
+  
+  convenience init(frame: CGRect) {
+    self.init()
+    
+    self.frame = frame
+    configure()
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("This class should be initialized with code")
+  }
+}
+
+
+// MARK: - Extension Configure Method
+
+extension BorderLayer {
+  
+  func configure() {
+    backgroundColor = UIColor.clear.cgColor
+    cornerRadius = frame.height / 22
+  }
+}
+

--- a/iOS/AreUDone/AreUDone/SceneDelegate.swift
+++ b/iOS/AreUDone/AreUDone/SceneDelegate.swift
@@ -11,54 +11,56 @@ import RealmSwift
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
   
+  // MARK: - Property
+  
   var window: UIWindow?
   
   private var sceneCoordinator: Coordinator!
+  private var isInitialNotification = true
+  private lazy var screenBorderAlertAnimator = ScreenBorderAlertAnimator(
+    borderLayer: borderLayer
+  )
+  private lazy var borderLayer: BorderLayer = {
+    let rootView = window?.rootViewController?.view
+    let frame = rootView?.frame ?? .zero
+    
+    let borderLayer = BorderLayer(frame: frame)
+    rootView?.layer.addSublayer(borderLayer)
+    return borderLayer
+  }()
+  
+  
+  // MARK: - Method
   
   func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
-    guard
-      let url = URLContexts.first?.url,
-      url.absoluteString.starts(with: "areudoneios://"),
-      let token = url.absoluteString.split(separator: "=").last.map({ String($0) }),
-      let decodedToken = token.removingPercentEncoding
-    else { return }
-
-    Keychain.shared.save(value: decodedToken, forKey: "token")
-    
-    let tokenParser = TokenParser()
-    let items = tokenParser.decode(jwtToken: decodedToken)
-    
-    UserIdStore.saveUserId(with: items)
-
-    sceneCoordinator.start()
+    signIn(by: URLContexts)
   }
   
   func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-    print(Realm.Configuration.defaultConfiguration.fileURL)
-
     guard let windowScene = (scene as? UIWindowScene) else { return }
     window = UIWindow(windowScene: windowScene)
+    let router = Router()
     
-//    Keychain.shared.removeValue(forKey: "token") // TODO:- 테스트용 코드
+    //    Keychain.shared.removeValue(forKey: "token") // TODO:- 테스트용 코드
     
-    sceneCoordinator = SceneCoordinator(
-      window: window, router: Router(),
-      factory: InitCoorndinatorFactory(),
-      signinChecker: SigninChecker()
+    configureSceneCoordinator(
+      router: router,
+      window: window ?? UIWindow(windowScene: windowScene)
     )
-    sceneCoordinator.start()
+    configureNetworkMonitor(router: router)
+    configureNotification()
   }
   
   func sceneDidDisconnect(_ scene: UIScene) {
-  
+    
   }
   
   func sceneDidBecomeActive(_ scene: UIScene) {
-   
+    
   }
   
   func sceneWillResignActive(_ scene: UIScene) {
-   
+    
   }
   
   func sceneWillEnterForeground(_ scene: UIScene) {
@@ -68,6 +70,74 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
   func sceneDidEnterBackground(_ scene: UIScene) {
     NotificationCenter.default.post(name: Notification.Name("back"), object: nil)
   }
+}
+
+
+// MARK: - Extension Configure Method
+
+private extension SceneDelegate {
   
+  func configureSceneCoordinator(router: Routable, window: UIWindow) {
+    sceneCoordinator = SceneCoordinator(
+      window: window, router: router,
+      factory: InitCoorndinatorFactory(),
+      signinChecker: SigninChecker()
+    )
+    sceneCoordinator.start()
+  }
   
+  func configureNetworkMonitor(router: Routable) {
+    let monitor = NWMonitor(router: router)
+    monitor.start()
+  }
+  
+  func configureNotification() {
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(networkChanged),
+      name: Notification.Name.networkChanged,
+      object: nil
+    )
+  }
+}
+
+// MARK: - Extension
+
+private extension SceneDelegate {
+  
+  func signIn(by URLContexts: Set<UIOpenURLContext>) {
+    guard
+      let url = URLContexts.first?.url,
+      url.absoluteString.starts(with: "areudoneios://"),
+      let token = url.absoluteString.split(separator: "=").last.map({ String($0) }),
+      let decodedToken = token.removingPercentEncoding
+    else { return }
+    
+    let tokenParser = TokenParser()
+    let items = tokenParser.decode(jwtToken: decodedToken)
+    
+    Keychain.shared.save(value: decodedToken, forKey: "token")
+    UserIdStore.saveUserId(with: items)
+    
+    sceneCoordinator.start()
+  }
+}
+
+
+// MARK: - Extension objc Method
+
+extension SceneDelegate {
+  
+  @objc func networkChanged(notification: Notification) {
+    DispatchQueue.main.async {
+      guard
+        let networkState = notification.userInfo?["networkState"] as? Bool, !self.isInitialNotification
+      else {
+        self.isInitialNotification = false
+        return
+      }
+      
+      self.screenBorderAlertAnimator.start(networkState: networkState)
+    }
+  }
 }

--- a/iOS/AreUDone/AreUDone/Service/BoardService/BoardService.swift
+++ b/iOS/AreUDone/AreUDone/Service/BoardService/BoardService.swift
@@ -65,8 +65,26 @@ final class BoardService: BoardServiceProtocol {
   }
   
   func createBoard(withTitle title: String, color: String, completionHandler: @escaping (Result<Void, APIError>) -> Void) {
-    router.request(route: BoardEndPoint.createBoard(title: title, color: color)) { result in
-      completionHandler(result)
+    let endPoint = BoardEndPoint.createBoard(title: title, color: color)
+    
+    router.request(route: endPoint) { result in
+      switch result {
+      case .success(_):
+        completionHandler(.success(()))
+        
+      case .failure(_):
+        if let localDataSource = self.localDataSource {
+          // 실패 시 endpoint save
+          let orderedEndpoint = OrderedEndPoint(value: endPoint.toDictionary())
+          localDataSource.save(orderedEndPoint: orderedEndpoint)
+          
+          completionHandler(.success(()))
+        } else {
+          completionHandler(result)
+        }
+      }
+      
+      
     }
   }
   
@@ -118,4 +136,5 @@ final class BoardService: BoardServiceProtocol {
     }
   }
 }
+
 

--- a/iOS/AreUDone/AreUDone/Service/BoardService/BoardService.swift
+++ b/iOS/AreUDone/AreUDone/Service/BoardService/BoardService.swift
@@ -10,13 +10,7 @@ import NetworkFramework
 
 protocol BoardServiceProtocol: class {
   
-  /* BoardService 는 로컬에서 갱신을 하지 않고 매번 API 로 데이터를 받아오기 때문에 fetchAllBoards 에서만 처리
-   API 받아오고 저장된 데이터와 비교하여 같으면 save 하지 않고 같지 않으면 새로 save?
-   
-   */
-  
-  
-  func fetchAllBoards(completionHandler: @escaping (Result<Boards, APIError>) -> Void) // success 시 API로부터 받아오고 realm 에 save, fail 시 realm 으로부터 load
+  func fetchAllBoards(completionHandler: @escaping (Result<Boards, APIError>) -> Void) 
   func createBoard(withTitle title: String, color: String, completionHandler: @escaping (Result<Void, APIError>) -> Void)
   func updateBoard(withBoardId boardId: Int, title: String, completionHandler: @escaping (Result<Void, APIError>) -> Void)
   func deleteBoard(with boardId: Int, completionHandler: @escaping (Result<Void, APIError>) -> Void)
@@ -29,8 +23,8 @@ final class BoardService: BoardServiceProtocol {
   
   // MARK: - Property
   
-  private let router: Routable // remote
-  private let localDataSource: BoardLocalDataSourceable? // local (realm)
+  private let router: Routable
+  private let localDataSource: BoardLocalDataSourceable?
   
   
   // MARK: - Initializer
@@ -48,7 +42,7 @@ final class BoardService: BoardServiceProtocol {
       switch result {
       case .success(let boards):
         completionHandler(.success(boards))
-        self.localDataSource?.save(boards: boards) // 같은 쓰레드??? 에서 돌려야한다고함
+        self.localDataSource?.save(boards: boards)
       
       case .failure(_):
         DispatchQueue.main.async {
@@ -83,8 +77,6 @@ final class BoardService: BoardServiceProtocol {
           completionHandler(result)
         }
       }
-      
-      
     }
   }
   


### PR DESCRIPTION
# 오프라인에서 보드 목록 추가 시 Realm 에 EndPoint 및 보드 정보 저장

## 📎 해당 이슈

#311 #342 

## 🛠 구현 내용 

- 네트워크 연결 관찰하는 객체 구현
- 끊어짐이 감지될 시 화면에 표시
- Realm 에서 사용할 수 있는 EndPointabe 채택 객체 구현
- EndPoint 객체를 EndPointable 클래스로 변경하는 로직 구현
- 오프라인에서 보드 추가 시 EndPoint 저장 및 온라인으로 전환 시 동기화되도록 구현

## 🙋‍ 리뷰어 참고 사항 

