### PR TITLE
axios interceptor 설정 변경 및 보드, 카드 생성 오류 수정

### DIFF
--- a/client/src/components/boardPage/AddListOrCard.js
+++ b/client/src/components/boardPage/AddListOrCard.js
@@ -100,7 +100,7 @@ const AddListBtnInput = ({ parent, id, history }) => {
             lists: [
                 ...boardDetail.lists,
                 {
-                    id: responseData.listId,
+                    id: responseData.id,
                     title: responseData.title,
                     position: responseData.position,
                     cards: [{ id: 0 }],

--- a/client/src/components/common/CreateBoardModal.js
+++ b/client/src/components/common/CreateBoardModal.js
@@ -1,6 +1,7 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import styled from 'styled-components';
 import { GithubPicker } from 'react-color';
+import { Modal, Input } from 'antd';
 import { createBoard } from '../../utils/boardRequest';
 
 const DimmedModal = styled.div`
@@ -48,14 +49,8 @@ const CloseModalBtn = styled.button`
 
 const ModalContents = styled.div``;
 
-const BoardTitleInput = styled.input.attrs({
-    placeholder: '보드 타이틀을 입력하세요.',
-})`
-    width: 100%;
+const BoardTitleInput = styled(Input)`
     margin-bottom: 10px;
-    padding: 5px;
-    border: ${(props) => props.theme.border};
-    border-radius: ${(props) => props.theme.radiusSmall};
 `;
 
 const Wrapper = styled.div`
@@ -72,16 +67,12 @@ const AddButton = styled.button.attrs({
     font-size: 18px;
 `;
 
-const Modal = ({ onClose, visible }) => {
-    const [title, setTitle] = useState('');
-    const [color, setColor] = useState('#ffffff');
+const CreateBoardModal = ({ onClose, visible }) => {
+    const [color, setColor] = useState('#B80000');
+    const inputTitleElement = useRef();
 
     const onClickChangeColor = ({ hex }) => {
         setColor(hex);
-    };
-
-    const createBoardInputHandler = (event) => {
-        setTitle(event.target.value);
     };
 
     const onDimmedClick = (e) => {
@@ -90,7 +81,29 @@ const Modal = ({ onClose, visible }) => {
         }
     };
 
-    const addBoard = async () => {
+    const showInvalidTitleModal = () => {
+        Modal.info({
+            title: '생성할 보드 제목을 입력해주세요😩',
+            onOk() {
+                inputTitleElement.current.focus();
+            },
+            style: { top: '40%' },
+        });
+    };
+
+    const checkInputHandler = (e) => {
+        if (e.keyCode !== undefined && e.keyCode !== 13) return false;
+        const replacedTitle = inputTitleElement.current.state.value?.replace(/ /g, '');
+        if (!replacedTitle) {
+            showInvalidTitleModal();
+            return false;
+        }
+        return true;
+    };
+
+    const addBoard = async (e) => {
+        if (!checkInputHandler(e)) return;
+        const title = inputTitleElement.current.state.value;
         const { data } = await createBoard({ title, color });
         document.location = `/board/${data.id}`;
     };
@@ -102,7 +115,13 @@ const Modal = ({ onClose, visible }) => {
                 <ModalInner color={color}>
                     <CloseModalBtn onClick={onClose}>X</CloseModalBtn>
                     <ModalContents>
-                        <BoardTitleInput value={title} onChange={createBoardInputHandler} />
+                        <BoardTitleInput
+                            ref={inputTitleElement}
+                            autoFocus="autoFocus"
+                            type="text"
+                            placeholder="보드 타이틀을 입력하세요."
+                            onKeyDown={addBoard}
+                        />
                         <Wrapper>
                             <GithubPicker width={212} onChangeComplete={onClickChangeColor} />
                             <AddButton onClick={addBoard}>생성</AddButton>
@@ -114,4 +133,4 @@ const Modal = ({ onClose, visible }) => {
     );
 };
 
-export default Modal;
+export default CreateBoardModal;

--- a/client/src/utils/request.js
+++ b/client/src/utils/request.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-alert */
 import axios from 'axios';
 
 const instance = axios.create({
@@ -12,6 +11,9 @@ const instance = axios.create({
 instance.interceptors.request.use(
     (config) => {
         const newConfig = config;
+        const reg = /^Bearer /;
+        const token = localStorage.getItem('jwt');
+        if (token === null || !reg.test(token)) window.location.href = '/login';
         newConfig.headers.Authorization = localStorage.getItem('jwt');
         return newConfig;
     },

--- a/client/src/utils/request.js
+++ b/client/src/utils/request.js
@@ -20,39 +20,13 @@ instance.interceptors.request.use(
 
 instance.interceptors.response.use(
     (response) => {
-        const { status } = response;
-        switch (status) {
-            case 200:
-            case 204:
-                break;
-            case 201:
-                // alert('정상적으로 생성되었습니다.');
-                break;
-            default:
-                break;
-        }
         return response;
     },
 
     (error) => {
-        const { status, data } = error.response;
-        switch (status) {
-            case 400:
-            case 409:
-                alert(data.error.message);
-                break;
-            case 401:
-                window.location.href = '/login';
-                break;
-            case 403:
-                alert(data.error.message);
-                break;
-            case 404:
-                alert(data.error.message);
-                break;
-            default:
-                alert(data.error.message);
-        }
+        const { status } = error.response;
+        if (status === 401) window.location.href = '/login';
+        return error.response;
     },
 );
 


### PR DESCRIPTION
# axios interceptor 설정 수정 및 보드 생성, 카드 생성 에러 수정

## 📎 해당 이슈

이슈 링크 (#369, #372, #362)

## 🛠 구현 내용 

- axios interceptor 설정 변경
- 타이틀이 입력되지 않은 보드가 생성되는 오류 수정
- 리스트 생성 후, 생성한 리스트에 카드 생성이 안되는 오류 수정

## 🙋‍ 리뷰어 참고 사항 
![image](https://user-images.githubusercontent.com/49746644/102472747-f20c5300-4099-11eb-828f-2cf516cb1bcb.png)

axios 요청 전, localstorage에 저장된 토큰값이 null이거나 올바르지 않을 경우 로그인 페이지로 redirect 하도록 수정했습니다.
axios 응답 후, 401 에러만 로그인 페이지로 redirect하도록 하고 나머지 에러는 API 호출 메소드에서 처리할 수 있도록 에러객체를 반환해주도록 설정을 변경하였습니다.