### PR TITLE
가로 스크롤 마우스 휠 이벤트 추가

### DIFF
--- a/client/src/components/boardPage/List.js
+++ b/client/src/components/boardPage/List.js
@@ -215,7 +215,7 @@ export default function List({ title, id, index, moveList, position }) {
 
     return (
         <>
-            <ListWrapper ref={ref} opacity={opacity} cursor={cursor}>
+            <ListWrapper ref={ref} opacity={opacity} cursor={cursor} className="list">
                 <ListContentWrapper>
                     {!titleInputState && (
                         <TitleDiv onClick={() => setTitleInputState(true)}>{title}</TitleDiv>

--- a/client/src/components/boardPage/index.js
+++ b/client/src/components/boardPage/index.js
@@ -79,6 +79,8 @@ const Board = ({ match }) => {
     }, [id]);
 
     const onMouseWheel = (e) => {
+        const isListArea = !!e.target.closest('.list');
+        if (isListArea) return;
         boardWrapper.current.scrollBy({ left: e.deltaY * 2, behavior: 'smooth' });
     };
 

--- a/client/src/components/boardPage/index.js
+++ b/client/src/components/boardPage/index.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-unused-vars */
-import React, { useContext, useEffect, useState, useCallback } from 'react';
+import React, { useContext, useEffect, useState, useCallback, useRef } from 'react';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import update from 'immutability-helper';
@@ -36,6 +36,7 @@ const Wrapper = styled.div`
 const ListWrapper = styled.div``;
 
 const Board = ({ match }) => {
+    const boardWrapper = useRef();
     const { id } = match.params;
     const [sidebarDisplay, setSidebarDisplay] = useState(false);
     const [invitedDropdownDisplay, setInvitedDropdownDisplay] = useState({
@@ -77,19 +78,23 @@ const Board = ({ match }) => {
         setBoardDetail(data);
     }, [id]);
 
+    const onMouseWheel = (e) => {
+        boardWrapper.current.scrollBy({ left: e.deltaY * 2, behavior: 'smooth' });
+    };
+
     return (
         <>
             <BoardsProvider>
                 <Header />
             </BoardsProvider>
-            <MainContents backgroundColor={boardDetail.color}>
+            <MainContents backgroundColor={boardDetail.color} onWheel={onMouseWheel}>
                 <TopMenu
                     sidebarDisplay={sidebarDisplay}
                     setSidebarDisplay={setSidebarDisplay}
                     setInvitedDropdownDisplay={setInvitedDropdownDisplay}
                     setAskoverDropdownDisplay={setAskoverDropdownDisplay}
                 />
-                <Wrapper sidebar={sidebarDisplay}>
+                <Wrapper ref={boardWrapper} sidebar={sidebarDisplay}>
                     {Boolean(boardDetail.lists?.length) && (
                         <DndProvider backend={HTML5Backend}>
                             <ListWrapper style={{ display: 'flex' }}>


### PR DESCRIPTION
# 가로 스크롤 마우스 휠 이벤트 추가

## 📎 해당 이슈

이슈 링크 (#379)

## 🛠 구현 내용 

- 가로 스크롤 마우스 휠 이벤트 추가

## 🙋‍ 리뷰어 참고 사항 

보드 상세페이지에서 리스트의 개수가 많을 경우 마우스 휠로 가로 스크롤이 가능합니다!
아래로 휠하면 우로 위로 휠하면 좌로 이동하도록 했습니다!