### PR TITLE
카드 수정 시, dueDate가 현재 시간으로 변경되는 오류 수정

### DIFF
--- a/server/src/service/CardService.js
+++ b/server/src/service/CardService.js
@@ -132,7 +132,7 @@ export class CardService extends BaseService {
         card.title = title;
         card.content = content;
         card.position = position;
-        card.dueDate = dueDate;
+        card.dueDate = dueDate || card.dueDate;
 
         await this.cardRepository.save(card);
     }

--- a/server/test/service/card/CardService.modifyCardById.test.js
+++ b/server/test/service/card/CardService.modifyCardById.test.js
@@ -64,7 +64,7 @@ describe('CardService.modifyCardById() Test', () => {
                 title: 'card update title',
                 content: undefined,
                 position: undefined,
-                dueDate: moment('2020-12-30T13:40:00').format(),
+                dueDate: undefined,
             };
 
             // when
@@ -86,7 +86,7 @@ describe('CardService.modifyCardById() Test', () => {
             expect(updatedCard.content).toEqual(card1.content);
             expect(updatedCard.position).toEqual(card1.position);
             expect(moment(updatedCard.dueDate).tz('Asia/Seoul').format()).toEqual(
-                moment(updateData.dueDate).tz('Asia/Seoul').format(),
+                moment(card1.dueDate).tz('Asia/Seoul').format(),
             );
         });
     });


### PR DESCRIPTION
# 카드 수정 시, dueDate가 현재 시간으로 변경되는 오류 수정

## 📎 해당 이슈

이슈 링크 (#382 )

## 🛠 구현 내용 

- 카드 수정 시, dueDate가 현재 시간으로 변경되는 오류 수정
- 오류가 나는 상황으로 테스트 코드 변경

## 🙋‍ 리뷰어 참고 사항 

