### PR TITLE
일부 UI 수정

### DIFF
--- a/iOS/AreUDone/AreUDone/BoardAddScene/ViewModel/BoardAddViewModel.swift
+++ b/iOS/AreUDone/AreUDone/BoardAddScene/ViewModel/BoardAddViewModel.swift
@@ -59,7 +59,7 @@ final class BoardAddViewModel: BoardAddViewModelProtocol {
   // MARK: - Method
   
   func updateBoardTitle(to title: String) {
-    let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+    let trimmedTitle = title.trimmed
     boardTitle = trimmedTitle
   }
   

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/View/AddOrCancelView.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/View/AddOrCancelView.swift
@@ -127,7 +127,7 @@ private extension AddOrCancelView {
   @objc private func addButtonTapped() {
     guard
       let text = textFieldView.text,
-      !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+      !text.trimmed.isEmpty
     else { return }
     
     delegate?.addButtonTapped(listTitle: text)

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/View/AddOrCancelView.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/View/AddOrCancelView.swift
@@ -22,7 +22,7 @@ final class AddOrCancelView: UIView {
   private lazy var textFieldView: TextField = {
     let textField = TextField()
     textField.translatesAutoresizingMaskIntoConstraints = false
-    
+    textField.font = UIFont.nanumB(size: 18)
     textField.backgroundColor = .white
     textField.layer.cornerRadius = 5
     textField.layer.borderWidth = 0.2
@@ -125,12 +125,19 @@ private extension AddOrCancelView {
 private extension AddOrCancelView {
   
   @objc private func addButtonTapped() {
-    delegate?.addButtonTapped(listTitle: textFieldView.text ?? "")
+    guard
+      let text = textFieldView.text,
+      !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    else { return }
+    
+    delegate?.addButtonTapped(listTitle: text)
+    textFieldView.resetText()
   }
   
   @objc private func cancelButtonTapped() {
     delegate?.cancelButtonTapped()
     textFieldView.resignFirstResponder()
+    textFieldView.resetText()
   }
 }
 
@@ -151,5 +158,10 @@ final class TextField: UITextField {
   
   override public func editingRect(forBounds bounds: CGRect) -> CGRect {
     return bounds.inset(by: padding)
+  }
+  
+  func resetText() {
+    
+    text = .none
   }
 }

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/View/CollectionView/BoardDetailFooterView.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/View/CollectionView/BoardDetailFooterView.swift
@@ -55,6 +55,7 @@ final class BoardDetailFooterView: UICollectionReusableView, Reusable {
 private extension BoardDetailFooterView {
   
   func configure() {
+    
     addSubview(button)
     addSubview(titleInputView)
 
@@ -108,10 +109,7 @@ private extension BoardDetailFooterView {
 extension BoardDetailFooterView: AddOrCancelViewDelegate {
   
   func addButtonTapped(listTitle: String) {
-    let trimmedListTitle = listTitle.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard !trimmedListTitle.isEmpty else { return }
-    
-    listAddHandler?(trimmedListTitle)
+    listAddHandler?(listTitle)
     cancelButtonTapped()
   }
   

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/View/Controller/BoardDetailViewController.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/View/Controller/BoardDetailViewController.swift
@@ -134,6 +134,8 @@ private extension BoardDetailViewController {
   
   func configureNavigationBarAppearance(of navigationBar: UINavigationBar) {
     let navigationAppearance = UINavigationBarAppearance()
+    let font = UIFont.nanumB(size: 16)
+    navigationAppearance.titleTextAttributes = [NSAttributedString.Key.font: font]
     navigationAppearance.configureWithTransparentBackground()
     navigationAppearance.backgroundEffect = UIBlurEffect(style: .systemChromeMaterialDark)
     navigationBar.standardAppearance = navigationAppearance

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/ViewModel/BoardDetailViewModel.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/ViewModel/BoardDetailViewModel.swift
@@ -134,10 +134,11 @@ final class BoardDetailViewModel: BoardDetailViewModelProtocol {
   }
   
   func updateBoardTitle(to title: String) {
-    boardService.updateBoard(withBoardId: boardId, title: title) { result in
+    let trimmedTitle = title.trimmed
+    boardService.updateBoard(withBoardId: boardId, title: trimmedTitle) { result in
       switch result {
       case .success(()):
-        self.boardTitle = title
+        self.boardTitle = trimmedTitle
         
       case .failure(let error):
         self.updateBoardTitleHandler?(self.boardTitle)

--- a/iOS/AreUDone/AreUDone/BoardDetailScene/ViewModel/ListViewModel.swift
+++ b/iOS/AreUDone/AreUDone/BoardDetailScene/ViewModel/ListViewModel.swift
@@ -107,13 +107,16 @@ final class ListViewModel: ListViewModelProtocol {
   }
   
   func updateListTitle(to title: String) {
+    let trimmedTitle = title.trimmed
+    
     listService.updateList(
       ofId: list.id,
       position: nil,
-      title: title) { result in
+      title: trimmedTitle
+    ) { result in
       switch result {
       case .success(()):
-        self.listTitle = title
+        self.listTitle = trimmedTitle
         
       case .failure(let error):
         self.updateListTitleHandler?(self.listTitle)

--- a/iOS/AreUDone/AreUDone/CardAddScene/ViewModel/CardAddViewModel.swift
+++ b/iOS/AreUDone/AreUDone/CardAddScene/ViewModel/CardAddViewModel.swift
@@ -65,7 +65,7 @@ final class CardAddViewModel: CardAddViewModelProtocol {
   // MARK: - Method
   
   func updateListTitle(to title: String) {
-    let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+    let trimmedTitle = title.trimmed
     cardTitle = trimmedTitle
   }
   

--- a/iOS/AreUDone/AreUDone/CardDetailScene/View/CommentView.swift
+++ b/iOS/AreUDone/AreUDone/CardDetailScene/View/CommentView.swift
@@ -137,7 +137,7 @@ private extension CommentView {
   
   @objc func commentTextFieldEditting() {
     guard let comment = commentTextField.text else { return }
-    let trimmedComment = comment.trimmingCharacters(in: .whitespacesAndNewlines)
+    let trimmedComment = comment.trimmed
     commentSaveButton.isEnabled = !trimmedComment.isEmpty ? true : false
   }
   
@@ -146,7 +146,7 @@ private extension CommentView {
       let comment = commentTextField.text,
       !comment.isEmpty
     else { return }
-    let trimmedComment = comment.trimmingCharacters(in: .whitespacesAndNewlines)
+    let trimmedComment = comment.trimmed
     
     delegate?.commentSaveButtonTapped(with: trimmedComment)
     commentSaveButton.isEnabled = false

--- a/iOS/AreUDone/AreUDone/CardDetailScene/View/StackView/CardDetailLocationView.swift
+++ b/iOS/AreUDone/AreUDone/CardDetailScene/View/StackView/CardDetailLocationView.swift
@@ -23,7 +23,7 @@ final class CardDetailLocationView: UIView {
   private lazy var listNameLabel: UILabel = {
     let label = UILabel()
     label.translatesAutoresizingMaskIntoConstraints = false
-    label.font = UIFont.nanumR(size: 14)
+    label.font = UIFont.nanumB(size: 16)
     
     return label
   }()
@@ -31,7 +31,25 @@ final class CardDetailLocationView: UIView {
   private lazy var boardNameLabel: UILabel = {
     let label = UILabel()
     label.translatesAutoresizingMaskIntoConstraints = false
+    label.font = UIFont.nanumB(size: 16)
+    
+    return label
+  }()
+  
+  private lazy var listDescriptionLabel: UILabel = {
+    let label = UILabel()
+    label.translatesAutoresizingMaskIntoConstraints = false
     label.font = UIFont.nanumR(size: 14)
+    label.text = "리스트에 있습니다"
+    
+    return label
+  }()
+  
+  private lazy var boardDescriptionLabel: UILabel = {
+    let label = UILabel()
+    label.translatesAutoresizingMaskIntoConstraints = false
+    label.font = UIFont.nanumR(size: 14)
+    label.text = "보드에 있습니다"
     
     return label
   }()
@@ -51,12 +69,12 @@ final class CardDetailLocationView: UIView {
   }
   
   func updateListNameLabel(with title: String) {
-    let text = title + " 리스트에 있습니다."
+    let text = title
     listNameLabel.text = text
   }
   
   func updateBoardNameLabel(with title: String) {
-    let text = title + " 보드에 있습니다."
+    let text = title
     boardNameLabel.text = text
   }
 }
@@ -71,10 +89,14 @@ private extension CardDetailLocationView {
     addSubview(titleLabel)
     addSubview(listNameLabel)
     addSubview(boardNameLabel)
+    addSubview(listDescriptionLabel)
+    addSubview(boardDescriptionLabel)
     
     configureTitleLabel()
     configureListNameLabel()
     configureBoardNameLabel()
+    configureListDescriptionLabel()
+    configureBoardDescriptionLabel()
   }
   
   func configureTitleLabel() {
@@ -87,18 +109,32 @@ private extension CardDetailLocationView {
   
   func configureListNameLabel() {
     NSLayoutConstraint.activate([
-      listNameLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 4),
+      listNameLabel.topAnchor.constraint(equalTo: boardNameLabel.bottomAnchor, constant: 5),
       listNameLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 25),
-      listNameLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -25),
+      listNameLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -5)
     ])
   }
   
   func configureBoardNameLabel() {
     NSLayoutConstraint.activate([
-      boardNameLabel.topAnchor.constraint(equalTo: listNameLabel.bottomAnchor, constant: 5),
+      boardNameLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 4),
       boardNameLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 25),
-      boardNameLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -25),
-      boardNameLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -5)
+    ])
+  }
+  
+  func configureListDescriptionLabel() {
+    NSLayoutConstraint.activate([
+      listDescriptionLabel.leadingAnchor.constraint(equalTo: listNameLabel.trailingAnchor, constant: 5),
+      listDescriptionLabel.firstBaselineAnchor.constraint(equalTo: listNameLabel.firstBaselineAnchor),
+      listDescriptionLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -25)
+    ])
+  }
+  
+  func configureBoardDescriptionLabel() {
+    NSLayoutConstraint.activate([
+      boardDescriptionLabel.leadingAnchor.constraint(equalTo: boardNameLabel.trailingAnchor, constant: 5),
+      boardDescriptionLabel.firstBaselineAnchor.constraint(equalTo: boardNameLabel.firstBaselineAnchor),
+      boardDescriptionLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -25)
     ])
   }
 }

--- a/iOS/AreUDone/AreUDone/Common/Extension/String+.swift
+++ b/iOS/AreUDone/AreUDone/Common/Extension/String+.swift
@@ -14,6 +14,10 @@ enum DateDividerFormat: String {
 
 extension String {
   
+  var trimmed: String {
+    self.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+  
   func toDateFormat(withDividerFormat dividerFormat: DateDividerFormat = .dash) -> Date {
     let dateFormatter = DateFormatter()
     let divider = dividerFormat.rawValue

--- a/iOS/AreUDone/AreUDone/InvitationScene/View/InvitationTableViewCell.swift
+++ b/iOS/AreUDone/AreUDone/InvitationScene/View/InvitationTableViewCell.swift
@@ -54,6 +54,7 @@ final class InvitationTableViewCell: UITableViewCell, Reusable {
 private extension InvitationTableViewCell {
   
   func configure() {
+    selectionStyle = .none
     addSubview(profileImageView)
     
     configureView()

--- a/iOS/AreUDone/AreUDone/InvitationScene/View/InvitationViewController.swift
+++ b/iOS/AreUDone/AreUDone/InvitationScene/View/InvitationViewController.swift
@@ -125,8 +125,7 @@ private extension InvitationViewController {
 extension InvitationViewController: UISearchResultsUpdating {
   
   func updateSearchResults(for searchController: UISearchController) {
-    guard let searchKeyword = searchController.searchBar.text,
-          !searchKeyword.isEmpty else { return }
+    guard let searchKeyword = searchController.searchBar.text else { return }
     
     debounce(time: 0.5) {
       self.viewModel.searchUser(of: searchKeyword)

--- a/iOS/AreUDone/AreUDone/InvitationScene/ViewModel/InvitationViewModel.swift
+++ b/iOS/AreUDone/AreUDone/InvitationScene/ViewModel/InvitationViewModel.swift
@@ -83,7 +83,7 @@ final class InvitationViewModel: InvitationViewModelProtocol {
   }
   
   func searchUser(of searchKeyword: String) {
-    let trimmedSearchKeyword = searchKeyword.trimmingCharacters(in: .whitespacesAndNewlines)
+    let trimmedSearchKeyword = searchKeyword.trimmed
     guard !trimmedSearchKeyword.isEmpty else {
       users = .none
       return

--- a/iOS/AreUDone/AreUDone/InvitationScene/ViewModel/InvitationViewModel.swift
+++ b/iOS/AreUDone/AreUDone/InvitationScene/ViewModel/InvitationViewModel.swift
@@ -82,8 +82,20 @@ final class InvitationViewModel: InvitationViewModelProtocol {
     }
   }
   
-  func searchUser(of userName: String) {
-    userService.fetchUserInfo(userName: userName) { result in
+  func searchUser(of searchKeyword: String) {
+    let trimmedSearchKeyword = searchKeyword.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmedSearchKeyword.isEmpty else {
+      users = .none
+      return
+    }
+    
+    var keyword = searchKeyword
+    
+    if trimmedSearchKeyword == "@developer" {
+      keyword = ""
+    }
+    
+    userService.fetchUserInfo(userName: keyword) { result in
       switch result {
       case .success(let users):
         self.users = users


### PR DESCRIPTION
# 일부 UI 수정

## 📎 해당 이슈
#392 

## 🛠 구현 내용 

- 카드 상세화면 카드 위치 UI 수정
- 리스트 추가 시 텍스트 뷰 초기화
- 보드상세화면에서 카드 상세화면으로 화면전환 했을 때 타이틀 폰트 변경
- 초대화면 테이블 뷰 셀렉트 옵션 삭제

## 🙋‍ 리뷰어 참고 사항 
없습니다
