### PR TITLE
dueDate변경시, 달력 상태 변경 오류 및 카드 이동 모달 컴포넌트의 위치 오류 수정

### DIFF
--- a/client/src/components/boardPage/AddListOrCard.js
+++ b/client/src/components/boardPage/AddListOrCard.js
@@ -112,7 +112,9 @@ const AddListBtnInput = ({ parent, id, history }) => {
 
     const setStateCard = (responseData) => {
         const { title, position } = responseData;
-        boardDetail.lists[boardDetail.lists.findIndex((v) => v.id === id)].cards.push({
+        const { cards } = boardDetail.lists[boardDetail.lists.findIndex((v) => v.id === id)];
+        if (cards[0].id === 0) cards.shift();
+        cards.push({
             id: responseData.id,
             title,
             dueDate: responseData.dueDate,

--- a/client/src/components/cardModal/CardDueDateContainer.js
+++ b/client/src/components/cardModal/CardDueDateContainer.js
@@ -8,6 +8,7 @@ import CardContext from '../../context/CardContext';
 import BoardDetailContext from '../../context/BoardDetailContext';
 import { modifyCardDueDate } from '../../utils/cardRequest';
 import { addNotification, removeNotification } from '../../utils/contentScript';
+import { CalendarDispatchContext, CalendarStatusContext } from '../../context/CalendarContext';
 
 const Wrapper = styled.div`
     display: grid;
@@ -56,15 +57,17 @@ const CardCloseButton = styled(CloseButton)`
 
 const CardDueDateContainer = ({ dueDate }) => {
     const [isDisplay, setIsDisplay] = useState(false);
+    const calendarStatus = useContext(CalendarStatusContext);
+    const calendarDispatch = useContext(CalendarDispatchContext);
     const { boardDetail, setBoardDetail } = useContext(BoardDetailContext);
     const { lists } = boardDetail;
     const { cardState, cardDispatch } = useContext(CardContext);
     const card = cardState.data;
     const listId = card.list.id;
-
     const dateFormat = 'YYYY-MM-DD HH:mm:ss';
 
     const onClickChangeDueDate = async (value) => {
+        const cardCount = calendarStatus?.cardCount;
         const cardId = card.id;
         const newDueDate = moment(new Date(value)).format('YYYY-MM-DD HH:mm:ss');
         await modifyCardDueDate({ cardId, dueDate: newDueDate });
@@ -72,16 +75,38 @@ const CardDueDateContainer = ({ dueDate }) => {
         removeNotification(cardId);
 
         const data = { ...card, dueDate: newDueDate };
-        const newBoardDetail = { ...boardDetail };
-        const listIndex = lists.findIndex((list) => list.id === listId);
-        const cardIndex = lists[listIndex].cards.findIndex((cardInfo) => cardInfo.id === card.id);
-        const currentCard = lists[listIndex].cards[cardIndex];
-        const newCard = { ...currentCard, dueDate: newDueDate };
-        newBoardDetail.lists[listIndex].cards[cardIndex] = newCard;
 
-        setBoardDetail(newBoardDetail);
         cardDispatch({ type: 'CHANGE_DUEDATE', data });
         addNotification(data);
+
+        if (cardCount) {
+            const oldDate = moment(dueDate).format('YYYY-MM-DD');
+            const newDate = moment(value).format('YYYY-MM-DD');
+            const oldCount = cardCount.find((item) => item.dueDate === oldDate)?.count;
+            const newCount = cardCount.find((item) => item.dueDate === newDate)?.count;
+            const oldCardCount = { dueDate: oldDate, count: oldCount ? oldCount - 1 : 0 };
+            const newCardCount = { dueDate: newDate, count: newCount ? newCount + 1 : 1 };
+            const newCardCounts = cardCount.filter(
+                (item) => item.dueDate !== oldDate && item.dueDate !== newDate,
+            );
+
+            calendarDispatch({
+                type: 'CHANGE_DUEDATE',
+                cardCount: [...newCardCounts, oldCardCount, newCardCount],
+            });
+        } else {
+            const newBoardDetail = { ...boardDetail };
+            const listIndex = lists.findIndex((list) => list.id === listId);
+            const cardIndex = lists[listIndex].cards.findIndex(
+                (cardInfo) => cardInfo.id === card.id,
+            );
+            const currentCard = lists[listIndex].cards[cardIndex];
+            const newCard = { ...currentCard, dueDate: newDueDate };
+            newBoardDetail.lists[listIndex].cards[cardIndex] = newCard;
+
+            setBoardDetail(newBoardDetail);
+        }
+
         setIsDisplay(false);
     };
 

--- a/client/src/components/provider/CardScrollProvider.js
+++ b/client/src/components/provider/CardScrollProvider.js
@@ -63,7 +63,7 @@ const CardScrollProvider = ({ children }) => {
         } catch (error) {
             cardScrollDispatch({ type: 'ERROR', error });
         }
-    }, [calendarStatus.selectedDate]);
+    }, [calendarStatus.selectedDate, calendarStatus.member]);
 
     return (
         <CardScrollStatusContext.Provider value={cardScrollState}>

--- a/client/src/components/provider/CardScrollProvider.js
+++ b/client/src/components/provider/CardScrollProvider.js
@@ -63,7 +63,7 @@ const CardScrollProvider = ({ children }) => {
         } catch (error) {
             cardScrollDispatch({ type: 'ERROR', error });
         }
-    }, [calendarStatus]);
+    }, [calendarStatus.selectedDate]);
 
     return (
         <CardScrollStatusContext.Provider value={cardScrollState}>

--- a/client/src/context/CalendarContext.js
+++ b/client/src/context/CalendarContext.js
@@ -40,6 +40,13 @@ export const CalendarReducer = (state, action) => {
                 cardCount,
             };
         }
+        case 'CHANGE_DUEDATE': {
+            const { cardCount } = action;
+            return {
+                ...state,
+                cardCount,
+            };
+        }
         default:
             throw new Error(`Unhandled action type: ${action.type}`);
     }


### PR DESCRIPTION
# dueDate변경시, 달력 상태 변경 오류 및 카드 이동 컴포넌트 오류 수정

## 📎 해당 이슈

이슈 링크 (#409 , #410 )

## 🛠 구현 내용 

- dueDate 변경시, 달력 상태도 변경되도록 수정
- 빈 리스트에 카드 생성 시, 카드 이동 모달 컴포넌트에 위치 정보가 없는 오류 수정

## 🙋‍ 리뷰어 참고 사항 

