### PR TITLE
댓글과 활동기록 생성 시간 타임존 수정

### DIFF
--- a/server/src/model/Activity.js
+++ b/server/src/model/Activity.js
@@ -1,10 +1,11 @@
+import moment from 'moment-timezone';
 import {
+    BeforeInsert,
     Column,
     Entity,
     JoinColumn,
     ManyToOne,
     PrimaryGeneratedColumn,
-    CreateDateColumn,
 } from 'typeorm';
 import { Board } from './Board';
 
@@ -20,6 +21,13 @@ export class Activity {
     @JoinColumn({ name: 'board_id' })
     board;
 
-    @CreateDateColumn({ name: 'created_at', type: 'datetime' })
+    @Column({ name: 'created_at', type: 'datetime' })
     createdAt;
+
+    @BeforeInsert()
+    beforeInsert() {
+        if (this.createdAt === null || this.createdAt === undefined) {
+            this.createdAt = moment().tz('Asia/Seoul').format();
+        }
+    }
 }

--- a/server/src/model/Board.js
+++ b/server/src/model/Board.js
@@ -9,10 +9,10 @@ export class Board {
     @PrimaryGeneratedColumn('increment', { type: 'int' })
     id;
 
-    @Column({ name: 'title', type: 'varchar' })
+    @Column({ name: 'title', type: 'varchar', charset: 'utf8mb4' })
     title;
 
-    @Column({ name: 'color', type: 'varchar' })
+    @Column({ name: 'color', type: 'varchar', charset: 'utf8mb4' })
     color;
 
     @ManyToOne(() => User, (user) => user.boards, { nullable: false })

--- a/server/src/model/Card.js
+++ b/server/src/model/Card.js
@@ -9,10 +9,10 @@ export class Card {
     @PrimaryGeneratedColumn('increment', { type: 'int' })
     id;
 
-    @Column({ name: 'title', type: 'varchar' })
+    @Column({ name: 'title', type: 'varchar', charset: 'utf8mb4' })
     title;
 
-    @Column({ name: 'content', type: 'varchar' })
+    @Column({ name: 'content', type: 'varchar', charset: 'utf8mb4' })
     content;
 
     @Column({ name: 'position', type: 'double' })

--- a/server/src/model/Comment.js
+++ b/server/src/model/Comment.js
@@ -15,7 +15,7 @@ export class Comment {
     @PrimaryGeneratedColumn('increment', { type: 'int' })
     id;
 
-    @Column({ name: 'content', type: 'varchar' })
+    @Column({ name: 'content', type: 'varchar', charset: 'utf8mb4' })
     content;
 
     @Column({ name: 'created_at', type: 'datetime' })

--- a/server/src/model/Comment.js
+++ b/server/src/model/Comment.js
@@ -1,6 +1,7 @@
+import moment from 'moment-timezone';
 import {
+    BeforeInsert,
     Column,
-    CreateDateColumn,
     Entity,
     JoinColumn,
     ManyToOne,
@@ -17,7 +18,7 @@ export class Comment {
     @Column({ name: 'content', type: 'varchar' })
     content;
 
-    @CreateDateColumn({ name: 'created_at', type: 'datetime' })
+    @Column({ name: 'created_at', type: 'datetime' })
     createdAt;
 
     @ManyToOne(() => User, (user) => user.comments, { nullable: false })
@@ -34,5 +35,12 @@ export class Comment {
         }
         this.content = content;
         return true;
+    }
+
+    @BeforeInsert()
+    beforeInsert() {
+        if (this.createdAt === null || this.createdAt === undefined) {
+            this.createdAt = moment().tz('Asia/Seoul').format();
+        }
     }
 }

--- a/server/src/model/List.js
+++ b/server/src/model/List.js
@@ -8,7 +8,7 @@ export class List {
     @PrimaryGeneratedColumn('increment', { type: 'int' })
     id;
 
-    @Column({ name: 'title', type: 'varchar' })
+    @Column({ name: 'title', type: 'varchar', charset: 'utf8mb4' })
     title;
 
     @Column({ name: 'position', type: 'double' })

--- a/server/src/model/User.js
+++ b/server/src/model/User.js
@@ -11,13 +11,13 @@ export class User {
     @PrimaryGeneratedColumn('increment', { type: 'int' })
     id;
 
-    @Column({ name: 'social_id', type: 'varchar' })
+    @Column({ name: 'social_id', type: 'varchar', charset: 'utf8mb4' })
     socialId;
 
-    @Column({ name: 'name', type: 'varchar' })
+    @Column({ name: 'name', type: 'varchar', charset: 'utf8mb4' })
     name;
 
-    @Column({ name: 'profile_image_url', type: 'varchar' })
+    @Column({ name: 'profile_image_url', type: 'varchar', charset: 'utf8mb4' })
     profileImageUrl;
 
     @OneToMany(() => Board, (board) => board.creator)


### PR DESCRIPTION
# 댓글과 활동기록 생성 시간 타임존 수정

## 📎 해당 이슈

이슈 링크 (#이슈 번호)

## 🛠 구현 내용 
- 댓글과 활동 기록 생성 시간을 moment로 생성
- 모든 테이블의 varchar 컬럼의 charset을 utf8mb4로 수정

## 🙋‍ 리뷰어 참고 사항 

